### PR TITLE
[TUTORS-292]: add footer to storybook

### DIFF
--- a/packages/tutors-ui/lib/Molecules/Footers/Footers.stories.ts
+++ b/packages/tutors-ui/lib/Molecules/Footers/Footers.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/svelte";
+
+import Footers from "./Footer.svelte";
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
+const meta = {
+    title: "Tutors/Molecules/Footers",
+    component: Footers,
+    tags: ["autodocs"]
+  } satisfies Meta<Footers>;
+  
+  export default meta;
+  type Story = StoryObj<typeof meta>;
+  
+  // More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
+  export const footers: Story = {};


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [x] The commit message is sensible and easily understood
- [ ] Tests for the changes have been added (for bug fixes / features where relevant)
- [ ] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Stuck for time so just a small update.
**Feature:** added the footer to story book

❓ Do we require any arguments for this component, width, height etc...?

#### Testing
```
cd packages/tutors-ui
nvm use 16.16.0
npm i
npm run storybook
```
Footer should display under the `Mocules`
![Screenshot 2023-03-16 at 12 30 48](https://user-images.githubusercontent.com/39221065/225617801-5acb7d66-9c82-40eb-b4ab-97785f0ed071.png)

#### What commits does this PR relate to?

[Issue-292](https://github.com/tutors-sdk/tutors/issues/292)

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
