### PR TITLE
Fix lab side nav not sticking

### DIFF
--- a/app/src/lib/ui/app-shells/CourseShell.svelte
+++ b/app/src/lib/ui/app-shells/CourseShell.svelte
@@ -95,7 +95,7 @@
     <SecondaryNavigator />
   </svelte:fragment>
   {#key $transitionKey}
-    <div id="app" class="h-full overflow-hidden">
+    <div id="app" class="h-full">
       <div id="top" />
       <div class="mx-auto my-4">
         <div in:fade={{ duration: 300, delay: 200 }}>


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [x] The commit message is sensible and easily understood
- [ ] Tests for the changes have been added (for bug fixes / features where relevant)
- [ ] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

The side navigation in labs currently doesn't stick even though it has `position: sticky;` set, which means when the user scrolls it doesn't follow. A sticky element is [_"offset relative to its nearest scrolling ancestor"_](https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky) (`overflow: scroll;`) so `overflow: hidden;` being set on `div#app` seems to be the culprit causing the issue.

Removing `overflow: hidden;` does not cause any visible UI errors as far as I can tell. I removed the attribute and navigated to different parts of the website and nothing looked out of place/missing/wrong. @edeleastar would you mind saying why you added it in https://github.com/tutors-sdk/tutors/commit/a30ba8bb3e5ef9d82599c34110adf116688366e2?

https://github.com/tutors-sdk/tutors/assets/99439005/323f0b9b-8e5a-460c-8667-9f540bd04e68

#### What commits does this PR relate to?

<!-- START pr-commits -->
<!-- END pr-commits -->

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
