### PR TITLE
Fix tutors links overflowing on mobile

### DIFF
--- a/app/src/lib/ui/navigators/Links.svelte
+++ b/app/src/lib/ui/navigators/Links.svelte
@@ -1,0 +1,16 @@
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
+  <div class="mx-auto">
+    <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/course/reference-course" target="_blank" rel="noreferrer"> Demo </a>
+  </div>
+  <div class="mx-auto">
+    <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/course/tutors-reference-manual" target="_blank" rel="noreferrer"
+    >Documentation</a
+    >
+  </div>
+  <div class="mx-auto sm:order-4">
+    <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/gallery" target="_blank" rel="noreferrer">Gallery</a>
+  </div>
+  <div class="mx-auto sm:order-3">
+    <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
+  </div>
+</div>

--- a/app/src/routes/(auth)/dashboard/Welcome.svelte
+++ b/app/src/routes/(auth)/dashboard/Welcome.svelte
@@ -10,20 +10,20 @@
       </p>
     </div>
     <div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
+        <div class="mx-auto">
           <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/course/reference-course" target="_blank" rel="noreferrer"> Demo </a>
         </div>
-        <div>
+        <div class="mx-auto">
           <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/course/tutors-reference-manual" target="_blank" rel="noreferrer"
-            >Documentation</a
+          >Documentation</a
           >
         </div>
-        <div>
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
-        </div>
-        <div>
+        <div class="mx-auto sm:order-4">
           <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/gallery" target="_blank" rel="noreferrer">Gallery</a>
+        </div>
+        <div class="mx-auto sm:order-3">
+          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
         </div>
       </div>
     </div>

--- a/app/src/routes/(auth)/dashboard/Welcome.svelte
+++ b/app/src/routes/(auth)/dashboard/Welcome.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Links from "$lib/ui/navigators/Links.svelte";
   export let session: any;
 </script>
 
@@ -10,22 +11,7 @@
       </p>
     </div>
     <div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
-        <div class="mx-auto">
-          <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/course/reference-course" target="_blank" rel="noreferrer"> Demo </a>
-        </div>
-        <div class="mx-auto">
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/course/tutors-reference-manual" target="_blank" rel="noreferrer"
-          >Documentation</a
-          >
-        </div>
-        <div class="mx-auto sm:order-4">
-          <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/gallery" target="_blank" rel="noreferrer">Gallery</a>
-        </div>
-        <div class="mx-auto sm:order-3">
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
-        </div>
-      </div>
+      <Links/>
     </div>
   </div>
 </div>

--- a/app/src/routes/(home)/TutorsLinks.svelte
+++ b/app/src/routes/(home)/TutorsLinks.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { modeCurrent } from "@skeletonlabs/skeleton";
+    import { modeCurrent } from "@skeletonlabs/skeleton";
 </script>
 
 <div class="bg-gradient-to-l from-primary-50 dark:from-primary-900 to-accent-50 dark:to-accent-900">
@@ -13,20 +13,20 @@
       <p class="font-bold !text-lg my-4">
         A collection of open source components & services supporting the creation of transformative learning experiences using open web standards.
       </p>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
+        <div class="mx-auto">
           <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/course/reference-course" target="_blank" rel="noreferrer"> Demo </a>
         </div>
-        <div>
+        <div class="mx-auto">
           <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/course/tutors-reference-manual" target="_blank" rel="noreferrer"
-            >Documentation</a
+          >Documentation</a
           >
         </div>
-        <div>
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
-        </div>
-        <div>
+        <div class="mx-auto sm:order-4">
           <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/gallery" target="_blank" rel="noreferrer">Gallery</a>
+        </div>
+        <div class="mx-auto sm:order-3">
+          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
         </div>
       </div>
     </div>

--- a/app/src/routes/(home)/TutorsLinks.svelte
+++ b/app/src/routes/(home)/TutorsLinks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { modeCurrent } from "@skeletonlabs/skeleton";
+    import Links from "$lib/ui/navigators/Links.svelte";
 </script>
 
 <div class="bg-gradient-to-l from-primary-50 dark:from-primary-900 to-accent-50 dark:to-accent-900">
@@ -13,22 +14,7 @@
       <p class="font-bold !text-lg my-4">
         A collection of open source components & services supporting the creation of transformative learning experiences using open web standards.
       </p>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 my-4">
-        <div class="mx-auto">
-          <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/course/reference-course" target="_blank" rel="noreferrer"> Demo </a>
-        </div>
-        <div class="mx-auto">
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/course/tutors-reference-manual" target="_blank" rel="noreferrer"
-          >Documentation</a
-          >
-        </div>
-        <div class="mx-auto sm:order-4">
-          <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all w-60" href="/gallery" target="_blank" rel="noreferrer">Gallery</a>
-        </div>
-        <div class="mx-auto sm:order-3">
-          <a class="btn btn-xl bg-surface-100-800-token font-bold hover:scale-105 transition-all w-60" href="/live" target="_blank" rel="noreferrer"> Live </a>
-        </div>
-      </div>
+      <Links/>
     </div>
     <div class="w-full lg:w-1/2">
       <img src={$modeCurrent ? "/tutors-reader-light.png" : "/tutors-reader-dark.png"} alt="tutors reader screenshot" />


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [ ] The commit message is sensible and easily understood
- [ ] Tests for the changes have been added (for bug fixes / features where relevant)
- [ ] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix. Fixes #639. The links in both TutorsLinks.svelte and Welcome.svelte were overflowing on mobile. To fix I added a media query via tailwind of 2 columns only above small screen size. In order to keep the colour scheme I ordered the divs appropriately,and reordered them above the small size. I then created a new custom component to eliminate reused code in both files called Links.svelte, placed in the src/lib/ui/navigators. This may not be the best place or name for this component, although it is what I judged best based on my limited knowledge of the codebase. 

Finally, I was unable to confirm that my code works on the dashboard page, as I was unable to navigate there on the build running on my machine due to github auth not working. I am fairly certain that it should work perfectly. 

#### What commits does this PR relate to?

<!-- START pr-commits -->

<!-- END pr-commits -->

#### Thank you for your contribution

We hope you stay around and connect with our growing community!

I am in first year in the Hdip at SETU and this is my first ever PR. While I have done my best to follow any established protocol, I am open to any feedback regarding my approach. Thank you. 

<img width="410" alt="Screenshot 2024-01-18 at 16 00 23" src="https://github.com/tutors-sdk/tutors/assets/65122189/608407b8-e77b-4566-ad0d-0c70d2e41750">
<img width="389" alt="Screenshot 2024-01-18 at 13 37 06" src="https://github.com/tutors-sdk/tutors/assets/65122189/a40b82ec-a1db-4d77-8543-dcdf7f3fbc3a">
