### PR TITLE
Auto-focus on search input upon component mount

### DIFF
--- a/src/routes/(course-reader)/search/[courseid]/+page.svelte
+++ b/src/routes/(course-reader)/search/[courseid]/+page.svelte
@@ -14,6 +14,7 @@
   let searchLos: Lo[] = [];
   let searchTerm = "";
   let searchResults: ResultType[] = [];
+  let searchInputElement;
 
   onMount(async () => {
     course = data.course;
@@ -23,6 +24,7 @@
     const notes = filterByType(data.course.los, "note");
     const panelNotes = filterByType(data.course.los, "panelnote");
     searchLos.push(...labs, ...steps, ...notes, ...panelNotes);
+    searchInputElement.focus()
   });
 
   function transformResults(results: ResultType[]) {
@@ -51,7 +53,7 @@
 <div class="card container mx-auto p-4">
   <label for="search" class="label"
     ><span>Enter search term:</span>
-    <input bind:value={searchTerm} type="text" name="search" id="search" class="m-2 p-2 input" placeholder="..." /></label
+    <input bind:value={searchTerm} bind:this={searchInputElement} type="text" name="search" id="search" class="m-2 p-2 input" placeholder="..." /></label
   >
   <div class="flex flex-wrap justify-center">
     {#each searchResults as result}


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [x] The commit message is sensible and easily understood
- [x] Tests for the changes have been added (for bug fixes / features where relevant)
- [x] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

#### Description
This PR enhances user experience by auto-focusing the search input upon the search component's mount, allowing users to start typing immediately without an additional click.

#### Technical Details
- Utilises bind:this={searchInputElement} for direct reference to the search input.
- Focuses on the input element using onMount lifecycle function in Svelte.

#### What commits does this PR relate to?

N/A - This is a new feature. Refers to issue #720 

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
