### PR TITLE
Increase search card click target and add hover for light/dark mode

### DIFF
--- a/src/routes/(course-reader)/search/[courseid]/+page.svelte
+++ b/src/routes/(course-reader)/search/[courseid]/+page.svelte
@@ -24,7 +24,7 @@
     const notes = filterByType(data.course.los, "note");
     const panelNotes = filterByType(data.course.los, "panelnote");
     searchLos.push(...labs, ...steps, ...notes, ...panelNotes);
-    searchInputElement.focus()
+    searchInputElement.focus();
   });
 
   function transformResults(results: ResultType[]) {
@@ -57,17 +57,17 @@
   >
   <div class="flex flex-wrap justify-center">
     {#each searchResults as result}
-      <div class="card m-1 w-full p-4 lg:w-72 2xl:w-96">
-        <div>
+      <div class="card m-1 w-full p-4 lg:w-72 2xl:w-96 hover:bg-gray-200 dark:hover:bg-gray-900">
+        <a rel="noopener noreferrer" href={result.link} target="_blank">
           <div>
-            {@html result.html}
-          </div>
-          <div class="pt-4 text-right text-sm">
-            <a rel="noopener noreferrer" href={result.link} target="_blank">
+            <div>
+              {@html result.html}
+            </div>
+            <div class="pt-4 text-right text-sm">
               {result.title}
-            </a>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
     {/each}
   </div>


### PR DESCRIPTION
#727 Addresses this issue

### Please check if the PR fulfills these requirements

- [x] The commit message is sensible and easily understood
- [x] Tests for the changes have been added (for bug fixes / features where relevant)
- [x] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This pull request introduces enhancements to the search result cards within the Tutors course search functionality, focusing on improving usability and visual feedback across different themes.

**Changes Made**
_Increased Clickable Area:_ Expanded the clickable target area by making the entire search result card clickable. This improvement addresses usability concerns, particularly on mobile devices, by providing a larger touch target.

_Added Hover Effect:_ Introduced a hover effect (hover:bg-gray-200 for light mode and dark:hover:bg-gray-900 for dark mode) for the search result cards. This addition not only enhances visual feedback when users interact with the cards but also ensures compatibility with both light and dark themes, maintaining visual consistency across the application.

**Impact**
_Improved Accessibility:_ The increased clickable area significantly enhances the accessibility of the search results, making the application more user-friendly, especially for users with motor impairments or those using touch devices.

_Enhanced User Experience:_ The addition of the hover effect provides immediate visual feedback, indicating interactivity and improving the overall user experience.


#### What commits does this PR relate to?

<!-- START pr-commits -->
<!-- END pr-commits -->

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
