### PR TITLE
comitting TutorsMessage change for adjusting to use a Github Pages so…

### DIFF
--- a/src/lib/ui/navigators/footers/TutorsMessage.svelte
+++ b/src/lib/ui/navigators/footers/TutorsMessage.svelte
@@ -1,8 +1,35 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import { convertMdToHtml } from "$lib/services/models/markdown-utils";
-  export let content =
-    "Why not pitch in to the [Tutors Project](https://tutors.dev)?: see [*Project Readme*](https://github.com/tutors-sdk/tutors/blob/development/README.md), [*Open Issues*](https://github.com/tutors-sdk/tutors/issues) & [*Gallery*](https://tutors.dev/gallery)";
-  let contentHtml = convertMdToHtml(content);
+  
+  let contentHtml = '';
+
+  async function fetchContent() {
+    try {
+      const response = await fetch('https://raw.githubusercontent.com/lgriffin/sampleTutorsPages/main/footer.md');
+      if (response.ok) {
+        const markdown = await response.text();
+        contentHtml = convertMdToHtml(markdown);
+      } else {
+        console.error('Failed to fetch content: ', response.statusText);
+        const fallbackContent =
+          "Why not pitch in to the [Tutors Project](https://tutors.dev)?: see [*Project Readme*](https://github.com/tutors-sdk/tutors/blob/development/README.md), [*Open Issues*](https://github.com/tutors-sdk/tutors/issues) & [*Gallery*](https://tutors.dev/gallery)";
+        contentHtml = convertMdToHtml(fallbackContent);
+      }
+    } catch (error) {
+      console.error('Error fetching content: ', error);
+      const fallbackContent =
+        "Why not pitch in to the [Tutors Project](https://tutors.dev)?: see [*Project Readme*](https://github.com/tutors-sdk/tutors/blob/development/README.md), [*Open Issues*](https://github.com/tutors-sdk/tutors/issues) & [*Gallery*](https://tutors.dev/gallery)";
+      contentHtml = convertMdToHtml(fallbackContent);
+    }
+  }
+
+  onMount(() => {
+    if (browser) {
+      fetchContent();
+    }
+  });
 </script>
 
 <p class="prose prose-sm prose-slate dark:prose-invert">


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [ ] The commit message is sensible and easily understood
- [ ] Tests for the changes have been added (for bug fixes / features where relevant)
- [ ] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This introduces a change to satisfy #705 by pointing the footer message to a Github Pages repo.

If @edeleastar can create a Gitlab Pages I can adjust the URL within the code to reflect a Github repo living under the Tutors-sdk project by pointing to the raw content. Optionally this can go one further and abstract it as a variable to a master config file (the .env perhaps) if a further issue wishes to explore this.

The footer is rendering slightly smaller than the current version, I played around with the markdown and if I use the header approach the font jumps signficantly, so a caution there, this should just be a flat text file with no real stylistic formatting. My CSS skills are too low to go exploring how to get this back to the right size so any suggestions and I can add them into the PR 

#### What commits does this PR relate to?

<!-- START pr-commits -->
TutorsMessage.svelte
<!-- END pr-commits -->

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
