### PR TITLE
i18n capabilities added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "^2.43.1",
         "d3": "^7.9.0",
         "echarts": "^5.5.0",
+        "sveltekit-i18n": "^2.4.2",
         "ws": "^8.17.0"
       },
       "devDependencies": {
@@ -82,7 +83,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -1285,7 +1285,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1299,7 +1298,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1308,7 +1306,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1316,14 +1313,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1913,6 +1908,19 @@
         "vite": "^5.0.0"
       }
     },
+    "node_modules/@sveltekit-i18n/base": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@sveltekit-i18n/base/-/base-1.3.7.tgz",
+      "integrity": "sha512-kg1kql1/ro/lIudwFiWrv949Q07gmweln87tflUZR51MNdXXzK4fiJQv5Mw50K/CdQ5BOk/dJ0WOH2vOtBI6yw==",
+      "peerDependencies": {
+        "svelte": ">=3.49.0"
+      }
+    },
+    "node_modules/@sveltekit-i18n/parser-default": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltekit-i18n/parser-default/-/parser-default-1.1.1.tgz",
+      "integrity": "sha512-/gtzLlqm/sox7EoPKD56BxGZktK/syGc79EbJAPWY5KVitQD9SM0TP8yJCqDxTVPk7Lk0WJhrBGUE2Nn0f5M1w=="
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
@@ -2211,8 +2219,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
@@ -2283,7 +2290,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2415,7 +2421,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2470,7 +2475,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
       "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
-      "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2733,7 +2737,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
       "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.1",
@@ -2815,7 +2818,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "dev": true,
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -3278,7 +3280,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3427,7 +3428,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -4023,7 +4023,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
       "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "*"
       }
@@ -4154,8 +4153,7 @@
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -4204,7 +4202,6 @@
       "version": "0.30.10",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
       "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
@@ -4316,8 +4313,7 @@
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4834,7 +4830,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
       "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
@@ -5487,7 +5482,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5693,7 +5687,6 @@
       "version": "4.2.16",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.16.tgz",
       "integrity": "sha512-mQwHpqHD2PmFcCyHaZ7XiTqposaLvJ75WpYcyY5/ce3qxbYtwQpZ+M7ZKP+2CG5U6kfnBZBpPLyofhlE6ROrnQ==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -5824,10 +5817,21 @@
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
       "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/sveltekit-i18n": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/sveltekit-i18n/-/sveltekit-i18n-2.4.2.tgz",
+      "integrity": "sha512-hjRWn4V4DBL8JQKJoJa3MRvn6d32Zo+rWkoSP5bsQ/XIAguPdQUZJ8LMe6Nc1rST8WEVdu9+vZI3aFdKYGR3+Q==",
+      "dependencies": {
+        "@sveltekit-i18n/base": "~1.3.0",
+        "@sveltekit-i18n/parser-default": "~1.1.0"
+      },
+      "peerDependencies": {
+        "svelte": ">=3.49.0"
       }
     },
     "node_modules/system-architecture": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@supabase/supabase-js": "^2.43.1",
     "d3": "^7.9.0",
     "echarts": "^5.5.0",
+    "sveltekit-i18n": "^2.4.2",
     "ws": "^8.17.0"
   }
 }

--- a/src/lib/translations/de/common.json
+++ b/src/lib/translations/de/common.json
@@ -1,0 +1,23 @@
+{
+    "developerExperience": {
+      "title": "Entwicklererfahrung",
+      "description": "Die <b>Entwicklererfahrung</b> priorisiert die Spezifikation und Implementierung von <b>robusten, gut dokumentierten, lose gekoppelten Komponenten und Diensten</b>, integriert in ein <b>kohärentes Toolkit</b>, das für Beiträge von <b>unterschiedlichen Fähigkeiten</b> offen ist."
+    },
+    "educatorExperience": {
+      "title": "Erziehererfahrung",
+      "description": "Die <b>Erziehererfahrung</b> priorisiert die Erstellung von <b>geführten Wegen</b> durch ein Curriculum mittels der Erstellung von Lernmaterialien, die <b>autonom, strukturell ausgerichtet, zusammensetzbar, prüfbar, erweiterbar, versioniert</b> und <b>unabhängig</b> sind."
+    },
+    "learnerExperience": {
+      "title": "Lernerfahrung",
+      "description": "Die <b>Lernerfahrung</b> priorisiert Web-Interaktionen, die <b>ansprechend, kontextuell, verlinkbar, durchsuchbar, zugänglich</b> und <b>responsiv</b> sind. Darüber hinaus sollte die Erfahrung ein Gefühl von <b>Gemeinschaft</b> und <b>Verbindung</b> unter den Lernenden fördern."
+    },
+    "valuesSection": {
+      "title": "Die <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Werte</span> des Projekts"
+    },
+    "creditsSection": {
+      "title": "Ein vollständig <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Open Source</span> Projekt",
+      "description": "Tutors ist ein Open Source-Projekt, das kostenlos unter der MIT-Lizenz auf GitHub verfügbar ist.",
+      "viewSource": "Quellcode anzeigen"
+    }
+  }
+  

--- a/src/lib/translations/en/common.json
+++ b/src/lib/translations/en/common.json
@@ -1,0 +1,22 @@
+{
+  "developerExperience": {
+    "title": "Developer Experience",
+    "description": "The <b>Developer Experience</b> prioritizes the specification and implementation of <b>robust, well-documented, loosely coupled components & services</b>, integrated into a <b>coherent toolkit</b> open to contributions from <b>diverse skill sets</b>."
+  },
+  "educatorExperience": {
+    "title": "Educator Experience",
+    "description": "The <b>Educator Experience</b> prioritizes the creation of <b>guided paths</b> through a curriculum via the creation of learning materials that are <b>autonomous, structurally aligned, composable, auditable, extensible, versioned</b> and <b>independent</b>."
+  },
+  "learnerExperience": {
+    "title": "Learner Experience",
+    "description": "The <b>Learner Experience</b> prioritizes web interactions that are <b>engaging, contextual, linkable, searchable, accessible</b> and <b>responsive</b>. In addition, the experience should foster a sense of <b>community</b> and <b>connection</b> among fellow learners."
+  },
+  "valuesSection": {
+    "title": "The <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Values</span> of the project"
+  },
+  "creditsSection": {
+    "title": "A fully <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Open Source</span> project",
+    "description": "Tutors is an open source project available for free under the MIT license on GitHub.",
+    "viewSource": "View Source Code"
+  }
+}

--- a/src/lib/translations/es/common.json
+++ b/src/lib/translations/es/common.json
@@ -1,0 +1,23 @@
+{
+    "developerExperience": {
+      "title": "Experiencia del desarrollador",
+      "description": "La <b>Experiencia del desarrollador</b> prioriza la especificación e implementación de <b>componentes y servicios robustos, bien documentados y de bajo acoplamiento</b>, integrados en un <b>conjunto de herramientas coherente</b> abierto a contribuciones de <b>diversas habilidades</b>."
+    },
+    "educatorExperience": {
+      "title": "Experiencia del educador",
+      "description": "La <b>Experiencia del educador</b> prioriza la creación de <b>rutas guiadas</b> a través de un currículo mediante la creación de materiales didácticos que son <b>autónomos, estructuralmente alineados, componibles, auditables, extensibles, versionados</b> y <b>independientes</b>."
+    },
+    "learnerExperience": {
+      "title": "Experiencia del estudiante",
+      "description": "La <b>Experiencia del estudiante</b> prioriza las interacciones web que son <b>atractivas, contextuales, enlazables, buscables, accesibles</b> y <b>responsivas</b>. Además, la experiencia debe fomentar un sentido de <b>comunidad</b> y <b>conexión</b> entre los estudiantes."
+    },
+    "valuesSection": {
+      "title": "Los <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 a secundario-500 bg-clip-text text-transparent box-decoration-clone\">Valores</span> del proyecto"
+    },
+    "creditsSection": {
+      "title": "Un proyecto completamente <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 a secundario-500 bg-clip-text text-transparent box-decoration-clone\">Open Source</span>",
+      "description": "Tutors es un proyecto de código abierto disponible de forma gratuita en GitHub bajo la licencia MIT.",
+      "viewSource": "Ver código fuente"
+    }
+  }
+  

--- a/src/lib/translations/fr/common.json
+++ b/src/lib/translations/fr/common.json
@@ -1,0 +1,22 @@
+{
+  "developerExperience": {
+    "title": "Expérience Développeur",
+    "description": "L'<b>Expérience développeur</b> donne la priorité à la spécification et à la mise en œuvre de <b>composants et services robustes, bien documentés et faiblement couplés</b>, intégrés dans une <b>boîte à outils cohérente</b> ouverte aux contributions de <b>ensembles de compétences diversifiés</b>."
+  },
+  "educatorExperience": {
+    "title": "Expérience éducateur",
+    "description": "L'<b>Expérience éducateur</b> donne la priorité à la création de <b>parcours guidés</b> à travers un programme via la création de supports d'apprentissage <b>autonomes, structurellement alignés, composables, auditables, extensibles, versionnés</b> et <b>indépendants</b>."
+  },
+  "learnerExperience": {
+    "title": "Expérience de l'apprenant",
+    "description": "L'<b>Expérience de l'apprenant</b> donne la priorité aux interactions Web qui sont <b>engageantes, contextuelles, pouvant être liées, consultables, accessibles</b> et <b>réactives</b>. De plus, l'expérience doit favoriser un sentiment de <b>communauté</b> et de <b>connexion</b> entre les autres apprenants."
+  },
+  "valuesSection": {
+    "title": "Les <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Valeurs</span> du projet"
+  },
+  "creditsSection": {
+    "title": "Un projet entièrement <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 à secondaire-500 bg-clip-text text-transparent box-decoration-clone\">Open Source</span>",
+    "description": "Tutors est un projet open source disponible gratuitement sous licence MIT sur GitHub.",
+    "viewSource": "Voir le code source"
+  }
+}

--- a/src/lib/translations/guide.md
+++ b/src/lib/translations/guide.md
@@ -1,0 +1,78 @@
+# Developer Guide: Adding a New Section to JSON Translation Files and Adjusting Svelte Pages
+
+This guide explains how to add a new section to your JSON translation files and adjust any Svelte page to use these translations. We'll use an example from the `DeveloperExperience` component.
+
+## 1. Adding a New Section to JSON Translation Files
+
+1. **Open the JSON Translation Files**:
+   Your translation files are located in `src/lib/translations`. You should have separate JSON files for each language, e.g., `en/common.json`, `fr/common.json`, etc.
+
+2. **Add the New Section**:
+   A section is a segment of our UI that we want to apply i18n principles to. In our JSON file it should be a standalone element. Let's add a new section called `newSection` with `title` and `description` keys in each JSON file -- you can add any unique key you wish. Here's an example.
+
+   **`src/lib/translations/en/common.json`**:
+   ```json
+   {
+     "developerExperience": {
+       "title": "Developer Experience",
+       "description": "The <b>Developer Experience</b> prioritizes the specification and implementation of <b>robust, well-documented, loosely coupled components & services</b>, integrated into a <b>coherent toolkit</b> open to contributions from <b>diverse skill sets</b>."
+     },
+     "newSection": {
+       "title": "New Section",
+       "description": "This is the description for the new section."
+     }
+   }
+
+
+   This newSection and it's equivilent keys need to be added to all relevant localisations that you are trying to cater for.
+
+## Adjusting a Svelte Page to Use the New Section
+
+We now need to find the appropriate Svelte page that currently serves up the text. In this example, let's adjust the DeveloperExperience.svelte component to include the new section.
+
+1. Open the Svelte Component:
+Open src/routes/(home)/values/DeveloperExperience.svelte.
+
+2. Import the Translation Function:
+Ensure you import the t function from your translations module.
+
+3. Use the translation keys
+
+For ease of use declare a variable to match each key and dynamically pull the value from the relevant dictionary
+ ```js
+let newSectionTitle = '';
+let newSectionDescription = '';
+
+newSectionTitle = $t('common.newSection.title');
+newSectionDescription = $t('common.newSection.description');
+```
+
+4. Style and Test:
+Ensure the new section is styled appropriately in your CSS, and test the page to ensure the translations appear correctly. Note that in the JSON file you can use HTML tags as the project converts JSON to HTML meaning we can use <b>bold</b> by using the relevant tags
+
+
+# Adding a new language
+
+This guide explains how to add a new language to your JSON translation files and adjust your Svelte pages to support this new language. We will use an example of adding the Irish language (`ie`) to our project.
+
+## 1. Adding a New Language to JSON Translation Files
+
+1. **Create the New JSON Translation File**:
+   Create a new JSON file for the Italian translations in the `src/lib/translations` directory. Name the file `ie/common.json`.
+
+2. **Populate the New JSON File**:
+   Add the necessary translations for your application and match the expected keys that exist in the other languages you are implementing.
+
+3. Update the Translation Loader:
+Ensure your translation configuration includes the new language. Open src/lib/translations/index.ts and add the loader for Irish
+
+```js
+{
+      locale: 'ie',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading Irish translations');
+        const module = await import('./ie/common.json');
+        return module.default as Translation;
+      },
+```

--- a/src/lib/translations/index.ts
+++ b/src/lib/translations/index.ts
@@ -1,0 +1,60 @@
+import i18n from 'sveltekit-i18n';
+import type { Config } from 'sveltekit-i18n';
+import type { Translation } from './types';
+
+const config: Config = {
+  loaders: [
+    {
+      locale: 'en',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading English translations');
+        const module = await import('./en/common.json');
+        return module.default as Translation;
+      },
+    },
+    {
+      locale: 'fr',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading French translations');
+        const module = await import('./fr/common.json');
+        return module.default as Translation;
+      },
+    },
+    {
+      locale: 'de',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading German translations');
+        const module = await import('./de/common.json');
+        return module.default as Translation;
+      },
+    },
+    {
+      locale: 'it',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading Italian translations');
+        const module = await import('./it/common.json');
+        return module.default as Translation;
+      },
+    },
+    {
+      locale: 'es',
+      key: 'common',
+      loader: async () => {
+        console.log('Loading Spanish translations');
+        const module = await import('./es/common.json');
+        return module.default as Translation;
+      },
+    },
+  ],
+};
+
+export const { t, locale, locales, loading, loadTranslations } = new i18n(config);
+
+export function setLocale(newLocale: string) {
+  console.log('Setting locale:', newLocale);
+  locale.set(newLocale);
+}

--- a/src/lib/translations/it/common.json
+++ b/src/lib/translations/it/common.json
@@ -1,0 +1,23 @@
+{
+    "developerExperience": {
+      "title": "Esperienza dello sviluppatore",
+      "description": "L'<b>Esperienza dello sviluppatore</b> dà priorità alla specificazione e implementazione di <b>componenti e servizi robusti, ben documentati e a basso accoppiamento</b>, integrati in un <b>toolkit coerente</b> aperto ai contributi di <b>competenze diverse</b>."
+    },
+    "educatorExperience": {
+      "title": "Esperienza dell'educatore",
+      "description": "L'<b>Esperienza dell'educatore</b> dà priorità alla creazione di <b>percorsi guidati</b> attraverso un curriculum mediante la creazione di materiali didattici che sono <b>autonomi, strutturalmente allineati, componibili, auditabili, estensibili, versionati</b> e <b>indipendenti</b>."
+    },
+    "learnerExperience": {
+      "title": "Esperienza del discente",
+      "description": "L'<b>Esperienza del discente</b> dà priorità alle interazioni web che sono <b>coinvolgenti, contestuali, collegabili, ricercabili, accessibili</b> e <b>responsive</b>. Inoltre, l'esperienza dovrebbe favorire un senso di <b>comunità</b> e <b>connessione</b> tra i discenti."
+    },
+    "valuesSection": {
+      "title": "I <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Valori</span> del progetto"
+    },
+    "creditsSection": {
+      "title": "Un progetto completamente <span class=\"font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone\">Open Source</span>",
+      "description": "Tutors è un progetto open source disponibile gratuitamente su GitHub con licenza MIT.",
+      "viewSource": "Visualizza il codice sorgente"
+    }
+  }
+  

--- a/src/lib/translations/types.ts
+++ b/src/lib/translations/types.ts
@@ -1,0 +1,7 @@
+// This is more for type safety if we do want to use it in the project
+export type Translation = {
+    title: string;
+    description: string;
+    viewSource?: string; // Optional field for view source text in credits
+  };
+  

--- a/src/lib/ui/components/LanguageSwitcher.svelte
+++ b/src/lib/ui/components/LanguageSwitcher.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { setLocale } from '$lib/translations';
+
+  function changeLanguage(lang: string) {
+    const currentUrl = new URL(window.location.href);
+    currentUrl.searchParams.set('lang', lang);
+    window.location.href = currentUrl.toString();
+  }
+</script>
+
+<style>
+  .dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .dropdown-content {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 100%;
+    background-color: white;
+    padding: 5px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+    white-space: nowrap; /* Ensure it doesn't wrap the text */
+  }
+
+  .dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: inline-block;
+  }
+
+  .dropdown-content a:hover {
+    background-color: #f1f1f1;
+  }
+
+  .dropdown:hover .dropdown-content {
+    display: flex;
+    flex-direction: row; /* Arrange items horizontally */
+  }
+
+  .dropdown:hover .dropbtn {
+    background-color: #3e8e41;
+  }
+
+  .dropbtn {
+    padding: 12px;
+    cursor: pointer;
+  }
+</style>
+
+<div class="dropdown">
+  <div class="dropbtn">Language</div>
+  <div class="dropdown-content">
+    <a on:click={() => changeLanguage('en')}>English</a>
+    <a on:click={() => changeLanguage('fr')}>Français</a>
+    <a on:click={() => changeLanguage('de')}>Deutsch</a>
+    <a on:click={() => changeLanguage('it')}>Italiano</a>
+    <a on:click={() => changeLanguage('es')}>Español</a>
+  </div>
+</div>

--- a/src/routes/(home)/TutorsCredits.svelte
+++ b/src/routes/(home)/TutorsCredits.svelte
@@ -1,19 +1,33 @@
+<script lang="ts">
+  import { t, locale } from '$lib/translations';
+
+  let title = '';
+  let description = '';
+  let viewSource = '';
+
+  $: {
+    title = $t('common.creditsSection.title');
+    description = $t('common.creditsSection.description');
+    viewSource = $t('common.creditsSection.viewSource');
+  }
+</script>
+
 <div class="bg-gradient-to-l from-primary-50 dark:from-primary-900 to-accent-50 dark:to-accent-900">
   <div class="container lg:flex justify-center items-center mx-auto py-20">
     <div class="w-full px-4">
       <h1 class="font-bold !text-5xl inline-block my-4">
-        A fully <span class="font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone"
-          >Open Source</span
-        > project
+        {@html title}
       </h1>
-      <p class="font-bold !text-lg my-4">Tutors is an open source project available for free under the MIT license on GitHub.</p>
+      <p class="font-bold !text-lg my-4">
+        {@html description}
+      </p>
       <a href="https://github.com/tutors-sdk/tutors/graphs/contributors" target="_blank" rel="noreferrer">
         <img src="https://contrib.rocks/image?repo=tutors-sdk/tutors" alt="github contributors list" />
       </a>
       <div class="my-4">
-        <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all" href="https://github.com/tutors-sdk/tutors" target="_blank" rel="noreferrer"
-          ><iconify-icon icon="mdi:github" />&nbsp; View Source Code</a
-        >
+        <a class="btn btn-xl bg-primary-500 text-white font-bold hover:scale-105 transition-all" href="https://github.com/tutors-sdk/tutors" target="_blank" rel="noreferrer">
+          <iconify-icon icon="mdi:github" />&nbsp; {viewSource}
+        </a>
       </div>
     </div>
   </div>

--- a/src/routes/(home)/TutorsValues.svelte
+++ b/src/routes/(home)/TutorsValues.svelte
@@ -2,13 +2,17 @@
   import DeveloperExperience from "./values/DeveloperExperience.svelte";
   import LearnerExperience from "./values/LearnerExperience.svelte";
   import EducatorExperience from "./values/EducatorExperience.svelte";
+  import { t, locale } from '$lib/translations';
+
+  let valuesTitle = '';
+
+  $: valuesTitle = $t('common.valuesSection.title');
 </script>
 
 <div class="container py-5 mx-auto justify-center items-center">
   <div class="w-full m-4">
     <h2 class="font-bold !text-5xl inline-block">
-      The <span class="font-bold !text-5xl inline-block bg-gradient-to-br from-primary-500 to-secondary-500 bg-clip-text text-transparent box-decoration-clone">Values</span> of the
-      project
+      {@html valuesTitle}
     </h2>
   </div>
   <div class="w-full lg:flex justify-center my-12">

--- a/src/routes/(home)/values/DeveloperExperience.svelte
+++ b/src/routes/(home)/values/DeveloperExperience.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import ExperienceCard from "./ExperienceCard.svelte";
+  import { t, locale } from '$lib/translations';
 
-  const title = "Developer Experience";
+  let title = '';
+  let content = '';
+
+  $: {
+    title = $t('common.developerExperience.title');
+    content = $t('common.developerExperience.description');
+    console.log('Title:', title);
+    console.log('Content:', content);
+  }
+
   const icon = "ant-design:code-outlined";
   const link = "https://tutors.dev/course/tutors-reference-manual#tutors-values";
-  const content = `
-  The **_Developer Experience_** prioritises the specification and implementation of **robust**, 
-  **well documented**, **loosely coupled components & services**, integrated into a 
-  **coherent toolkit** open to contributions from **diverse skill sets**.
-  `;
 </script>
 
 <ExperienceCard {title} {icon} {link} {content} />

--- a/src/routes/(home)/values/EducatorExperience.svelte
+++ b/src/routes/(home)/values/EducatorExperience.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import ExperienceCard from "./ExperienceCard.svelte";
+  import { t, locale } from '$lib/translations';
+
+  let title = '';
+  let content = '';
+
+  $: {
+    title = $t('common.educatorExperience.title');
+    content = $t('common.educatorExperience.description');
+    console.log('Title:', title);
+    console.log('Content:', content);
+  }
 
   const icon = "mdi:teacher";
-  const title = "Educator Experience";
   const link = "https://tutors.dev/course/tutors-reference-manual#tutors-values";
-  const content = `
-  The **_Educator Experience_** prioritises the creation of a **guided paths** through a curriculum 
-  via the creation of learning materials that are **autonomous**, **structurally aligned**, **composable**, 
-  **auditable**, **extensible**, **versioned** and **independent**.
-  `;
 </script>
 
 <ExperienceCard {title} {icon} {link} {content} />

--- a/src/routes/(home)/values/ExperienceCard.svelte
+++ b/src/routes/(home)/values/ExperienceCard.svelte
@@ -4,7 +4,9 @@
   export let icon = "";
   export let title = "";
   export let content = "";
-  let contentHtml = convertMdToHtml(content);
+  let contentHtml = '';
+
+  $: contentHtml = convertMdToHtml(content);
 </script>
 
 <a href={link} target="_blank" rel="noreferrer">

--- a/src/routes/(home)/values/LearnerExperience.svelte
+++ b/src/routes/(home)/values/LearnerExperience.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
   import ExperienceCard from "./ExperienceCard.svelte";
+  import { t, locale } from '$lib/translations';
 
-  const title = "Learner Experience";
+  let title = '';
+  let content = '';
+
+  $: {
+    title = $t('common.learnerExperience.title');
+    content = $t('common.learnerExperience.description');
+    console.log('Title:', title);
+    console.log('Content:', content);
+  }
+
   const icon = "ph:student";
   const link = "https://tutors.dev/course/tutors-reference-manual#tutors-values";
-  const content = `
-  The **_Learner Experience_** prioritises web interactions that are **engaging**, **contextual**, 
-  **linkable**, **searchable**, **accessible** and **responsive**. In addition the experience 
-  should foster a sense of **community** and **connection** among fellow learners.
-`;
 </script>
 
 <ExperienceCard {title} {icon} {link} {content} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import { get } from 'svelte/store';
   import { getKeys } from "$lib/environment";
   import { initFirebase } from "$lib/services/utils/firebase-utils";
   import { computePosition, autoUpdate, flip, shift, offset, arrow } from "@floating-ui/dom";
   import { initializeStores, storePopup } from "@skeletonlabs/skeleton";
+  import { loadTranslations, setLocale } from '$lib/translations';
+  import LanguageSwitcher from '$lib/ui/components/LanguageSwitcher.svelte';
 
   initializeStores();
   const themes: any = ["tutors", "dyslexia", "halloween", "valentines"];
   storePopup.set({ computePosition, autoUpdate, flip, shift, offset, arrow });
 
+  // Handle navigation if the URL has a specific hash
   if ($page.url.hash.startsWith("#/course")) {
     goto($page.url.hash.slice(2));
   }
+
+  // Initialize translations when the component mounts
+  $: {
+    (async () => {
+      const url = get(page).url;
+      const initLocale = url.searchParams.get('lang') || 'en';
+      const pathname = url.pathname;
+
+      console.log('Initializing locale:', initLocale);
+      setLocale(initLocale);
+      await loadTranslations(initLocale, pathname);
+    })();
+  }
 </script>
+
+<LanguageSwitcher />
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,14 +1,22 @@
-import type { LayoutLoad } from "./$types";
-import { createBrowserClient, isBrowser, parse } from "@supabase/ssr";
-import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from "$env/static/public";
+import type { LayoutLoad } from './$types';
+import { createBrowserClient, isBrowser, parse } from '@supabase/ssr';
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { loadTranslations, setLocale } from '$lib/translations';
 
-export const load: LayoutLoad = async ({ fetch, data, depends }) => {
-  depends("supabase:auth");
+export const load: LayoutLoad = async ({ fetch, data, depends, url }) => {
+  depends('supabase:auth');
 
-  if (PUBLIC_SUPABASE_URL !== "XXX") {
+  const initLocale = url.searchParams.get('lang') || 'en';
+  const { pathname } = url;
+
+  console.log('Loading translations for locale:', initLocale, 'on pathname:', pathname);
+  setLocale(initLocale);
+  await loadTranslations(initLocale, pathname);
+
+  if (PUBLIC_SUPABASE_URL !== 'XXX') {
     const supabase = createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
       global: {
-        fetch
+        fetch,
       },
       cookies: {
         get(key) {
@@ -18,12 +26,12 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 
           const cookie = parse(document.cookie);
           return cookie[key];
-        }
-      }
+        },
+      },
     });
 
     const {
-      data: { session }
+      data: { session },
     } = await supabase.auth.getSession();
 
     return { supabase, session };


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [ ] The commit message is sensible and easily understood
- [ ] Tests for the changes have been added (for bug fixes / features where relevant)
- [ ] Docs have been added / updated (for bug fixes / features where relevant)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This brings a new feature that addresses #674. Specifically it brings in an extensible approach to i18n and the working example I have allows us to quickly change the text on several key components in the screen. I am pausing now for feedback as there are other components that would need updating but the PR is mature enough that you can see the workings of it on a subset of the screen. I used Google Translate to try and get some realistic language capabilities in place. I wrote a mini guide for extending it as well. Here are some to:dos that I have identified:

* Update the remaining page components, some of these look to be in a different project so I have to figure out how to grab and extend in that sense
* Get i18n icons that are open source to make the pop out menu I added a bit more usable
* Get actual native speakers to translate, I'm sure my google translate efforts leave a lot to be desired

@jouwdan and @edeleastar can you both take a look at this, check am I on the right path and give me any feedback on the layout I picked for components and naming conventions. I will chip away at this and rebase it later when I get time to add more components. The initial uplift is there though, the solution is scalable and shouldn't be too much challenge to modify the remaining svelte pages.

#### What commits does this PR relate to?

<!-- START pr-commits -->
<!-- END pr-commits -->

#### Thank you for your contribution

We hope you stay around and connect with our growing community!
