### PR TITLE
Update layout of cards

### DIFF
--- a/src/lib/ui/learning-objects/layout/Cards.svelte
+++ b/src/lib/ui/learning-objects/layout/Cards.svelte
@@ -7,6 +7,7 @@
 
   export let los: Lo[] = [];
   export let border: boolean = false;
+  export let inSidebar: boolean = false;
   let bordered = "border-[1px] border-surface-200-700-token";
   let unbordered = "";
 
@@ -35,11 +36,13 @@
 
 {#if los.length > 0}
   <div class="bg-surface-100-800-token mx-auto mb-2 place-items-center overflow-hidden rounded-xl p-4 {border ? bordered : unbordered}">
-    <div class="flex flex-wrap justify-center">
+    <div class="{los.length > 5 && !inSidebar ? 'grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5' : 'flex justify-center flex-wrap mx-auto'}">
       {#key refresh}
         {#each los as lo}
           {#if !lo.hide}
-            <Card {lo} />
+            <div class="flex justify-center">
+              <Card {lo} />
+            </div>
           {/if}
         {/each}
       {/key}

--- a/src/lib/ui/learning-objects/layout/Units.svelte
+++ b/src/lib/ui/learning-objects/layout/Units.svelte
@@ -3,32 +3,33 @@
   import { layout } from "$lib/stores";
   import { onDestroy } from "svelte";
   import Panels from "./Panels.svelte";
-  import Cards from "./Cards.svelte";
+  import Cards from "./Cards.svelte"; 
   import Image from "../../themes/Image.svelte";
   export let units: Composite[];
+  export let inSidebar: boolean = false; 
 
   let text = "!text-xl font-semibold";
   const unsubscribe = layout.subscribe((layout) => {
     if (layout === "compacted") {
       text = "!text-xl font-semibold";
     } else {
-      text = "!text-xl font-semibold";
+      text = "!text-xl font-semibold"; 
     }
   });
   onDestroy(unsubscribe);
 </script>
 
-{#each units as unit}
-  <div class="bg-surface-100-800-token mx-auto mb-2 w-full place-items-center overflow-hidden rounded-xl p-4 border-[1px] border-surface-200-700-token">
-    <div class="flex w-full justify-between pb-2">
-      <h2 id={unit.id} class="p-2 {text}">
-        {unit.title}
-      </h2>
-      <Image lo={unit.parentTopic ? unit.parentTopic : unit.parentLo} miniImage={true} />
+  {#each units as unit}
+    <div class="bg-surface-100-800-token mx-auto mb-2 w-full place-items-center overflow-hidden rounded-xl p-4 border-[1px] border-surface-200-700-token">
+      <div class="flex w-full justify-between pb-2">
+        <h2 id={unit.id} class="p-2 {text}">
+          {unit.title}
+        </h2>
+        <Image lo={unit.parentTopic ? unit.parentTopic : unit.parentLo} miniImage={true} />
+      </div>
+      <Panels panels={unit.panels} />
+      <div class="flex flex-wrap justify-center">
+        <Cards los={unit.units.standardLos} inSidebar={inSidebar} />
+      </div>
     </div>
-    <Panels panels={unit.panels} />
-    <div class="flex flex-wrap justify-center">
-      <Cards los={unit.units.standardLos} />
-    </div>
-  </div>
-{/each}
+  {/each}

--- a/src/lib/ui/learning-objects/layout/Wall.svelte
+++ b/src/lib/ui/learning-objects/layout/Wall.svelte
@@ -8,21 +8,21 @@
   let talkVideos = los.filter((lo) => lo.type !== "panelvideo");
 </script>
 
-<div class="container mx-auto">
+<div class="flex flex-wrap justify-center">
   {#key los}
     {#if type !== "video"}
       <Cards {los} />
     {:else}
       <div class="flex flex-wrap justify-center">
         {#each panelVideos as lo}
-          <div class="w-2/5 p-2 card m-2">
+          <div class="flex justify-center">
             <Video {lo} />
           </div>
         {/each}
       </div>
       <div class="flex flex-wrap justify-center">
         {#each talkVideos as lo}
-          <div class="w-2/5 p-2 card m-2">
+          <div class="flex justify-center">
             <Video {lo} />
           </div>
         {/each}

--- a/src/lib/ui/learning-objects/structure/Composite.svelte
+++ b/src/lib/ui/learning-objects/structure/Composite.svelte
@@ -12,10 +12,10 @@
     <div class="w-full">
       <Panels panels={composite.panels} />
       <Units units={composite.units.units} />
-      <Cards los={composite.units.standardLos} />
+      <Cards los={composite.units.standardLos} /> 
     </div>
-    <div class="block w-full md:w-[30rem] md:ml-2">
-      <Units units={composite.units?.sides} />
+    <div class="block w-full md:w-[30rem] md:ml-2 flex">
+      <Units units={composite.units?.sides} inSidebar={true} />
     </div>
   </div>
 {:else if composite}


### PR DESCRIPTION
#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature - Updates to Layout of Course Cards 

- Card groups are more contained
- Cards now start from the left on each new row, instead of starting from the middle
- The overall card group remains centred on the screen
- The grey background has been reduced in size
