### PR TITLE
Add layout text beside layout menu icon

### DIFF
--- a/src/lib/ui/navigators/LayoutMenu.svelte
+++ b/src/lib/ui/navigators/LayoutMenu.svelte
@@ -37,7 +37,10 @@
 </script>
 
 {#snippet menuSelector()}
-  <Icon type="lightMode" tip="Open Theme Menu" />
+  <div class="flex items-center">
+    <Icon type="lightMode" tip="Open Theme Menu" />
+    <span class="ml-2 hidden text-sm font-bold md:block">Layout</span>
+  </div>
 {/snippet}
 
 {#snippet menuContent()}

--- a/src/lib/ui/navigators/MainNavigator.svelte
+++ b/src/lib/ui/navigators/MainNavigator.svelte
@@ -35,14 +35,17 @@
   {/snippet}
   <CalendarButton />
   {#snippet trail()}
-    <span class="hidden md:block">
+    <div class="items-center md:flex">
       <TutorsTimeIndicator />
-      {#if currentCourse?.value && !currentCourse?.value?.isPortfolio}
-        <SearchButton />
-      {/if}
-      <span class="mx-2 h-10 w-[1px] bg-gray-400 dark:bg-gray-200"></span>
-    </span>
-    <LayoutMenu />
+      <div class="flex items-center">
+        {#if currentCourse?.value && !currentCourse?.value?.isPortfolio}
+          <SearchButton />
+        {/if}
+      </div>
+    </div>
+    <div class="flex items-center">
+      <LayoutMenu />
+    </div>
     <span class="mx-2 h-10 w-[1px] bg-gray-400 dark:bg-gray-200"></span>
     {#if !currentCourse?.value?.isPrivate}
       <div class="relative">


### PR DESCRIPTION
This PR adds the 'Layout' text back next to the layout menu icon (paintbrush) to better clarify where to go to update layout preferences.