### PR TITLE
Fix erroneous non-null assertion on sentiment assignment

### DIFF
--- a/src/lib/services/connect/services/connect.svelte.ts
+++ b/src/lib/services/connect/services/connect.svelte.ts
@@ -66,7 +66,7 @@ export const tutorsConnectService: TutorsConnectService = {
     if (user) {
       this.profile = supabaseProfile;
       tutorsId.value = user;
-      tutorsId.value.sentiment! = await getTutorsConnectUserSentiment(user.login) ?? "neutral";
+      tutorsId.value.sentiment = await getTutorsConnectUserSentiment(user.login) ?? "neutral";
       tutorsId.value.share = await getTutorsConnectUserOnlineStatus(user.login) ?? "online";
       addOrUpdateStudent(user);
       if (browser) {


### PR DESCRIPTION
## Summary

- Removes a no-op `!` non-null assertion on the left side of an assignment in `connect.svelte.ts:69`
- `tutorsId.value.sentiment! = await ...` — the `!` asserts the property is non-null *before* immediately overwriting it, which does nothing useful and is misleading

## Test plan

- [ ] Log in with GitHub, verify sentiment loads correctly on reconnect
- [ ] Change sentiment via the sentiment button, verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)