### PR TITLE
Fix CourseVisit.lastVisit type mismatch and null safety

### DIFF
--- a/src/lib/services/connect/services/localStorageProfile.ts
+++ b/src/lib/services/connect/services/localStorageProfile.ts
@@ -39,12 +39,12 @@ export const localStorageProfile: ProfileStore = {
     const visit = this.courseVisits.find((c) => c.id === course.courseId);
     if (visit) {
       visit.visits++;
-      visit.lastVisit = new Date();
+      visit.lastVisit = new Date().toISOString();
     } else {
       const courseVisit: CourseVisit = {
         id: course.courseId,
         title: course.title,
-        lastVisit: new Date(),
+        lastVisit: new Date().toISOString(),
         credits: course.properties.credits,
         visits: 1
       };

--- a/src/lib/services/connect/services/supabaseProfile.svelte.ts
+++ b/src/lib/services/connect/services/supabaseProfile.svelte.ts
@@ -55,12 +55,12 @@ export const supabaseProfile: ProfileStore = {
     const visit = this.courseVisits.find((c) => c.id === course.courseId);
     if (visit) {
       visit.visits++;
-      visit.lastVisit = new Date();
+      visit.lastVisit = new Date().toISOString();
     } else {
       const courseVisit: CourseVisit = {
         id: course.courseId,
         title: course.title,
-        lastVisit: new Date(),
+        lastVisit: new Date().toISOString(),
         credits: course.properties.credits,
         visits: 1
       };

--- a/src/lib/services/connect/types.ts
+++ b/src/lib/services/connect/types.ts
@@ -11,7 +11,7 @@ export type CourseVisit = {
   title: string;
   img?: string;
   icon?: IconType;
-  lastVisit: Date;
+  lastVisit: string;
   credits: string;
   visits?: number;
   private: boolean;

--- a/src/lib/services/connect/utils/allCourseAccess.ts
+++ b/src/lib/services/connect/utils/allCourseAccess.ts
@@ -49,7 +49,7 @@ function getCourseRecord(course: Course) {
   const courseVisit: CourseVisit = {
     id: course.courseId,
     title: course.title,
-    lastVisit: new Date(),
+    lastVisit: new Date().toISOString(),
     credits: course.properties.credits,
     private: course.isPrivate
   };

--- a/src/routes/(home)/CourseVisitCard.svelte
+++ b/src/routes/(home)/CourseVisitCard.svelte
@@ -16,7 +16,7 @@
       <p class="line-clamp-1">{courseVisit.credits}</p>
       <p class="line-clamp-1">
         Last Accessed: {courseVisit.lastVisit?.slice(0, 10)}
-        {courseVisit.lastVisit.slice(11, 19)}
+        {courseVisit.lastVisit?.slice(11, 19)}
       </p>
       <p>Visits: {courseVisit.visits}</p>
     </section>


### PR DESCRIPTION
## Summary

- `CourseVisit.lastVisit` was typed as `Date` but always arrives as a string after `JSON.parse()` (localStorage) or Supabase JSON deserialization — `.slice()` is a string method that would fail on a real `Date` object
- Changes the type from `Date` to `string` and uses `.toISOString()` at all 5 assignment sites
- Adds missing optional chaining (`?.`) on the second `.slice()` call in `CourseVisitCard.svelte` to prevent a crash when `lastVisit` is nullish

### Files changed

- `src/lib/services/connect/types.ts` — `lastVisit: Date` → `lastVisit: string`
- `src/lib/services/connect/services/supabaseProfile.svelte.ts` — `new Date()` → `new Date().toISOString()`
- `src/lib/services/connect/services/localStorageProfile.ts` — same
- `src/lib/services/connect/utils/allCourseAccess.ts` — same
- `src/routes/(home)/CourseVisitCard.svelte` — add `?.` on second `.slice()` call

## Test plan

- [ ] Log in, visit a course, go back to dashboard — "Last Accessed" date should display correctly
- [ ] Star/unstar a course — verify it moves between Favourites and Recently Accessed
- [ ] Delete a course visit — verify card is removed
- [ ] Check that a freshly visited course shows current date/time

🤖 Generated with [Claude Code](https://claude.com/claude-code)