### PR TITLE
Remove debug console.log statements

### DIFF
--- a/src/lib/services/community/services/catalogue.ts
+++ b/src/lib/services/community/services/catalogue.ts
@@ -50,7 +50,6 @@ export const catalogueService: CatalogueService = {
 
   async pruneCatalogue(fetchFunction: typeof fetch) {
     const catalogue = await this.getCatalogue();
-    console.log(`Total courses: ${catalogue.length}`);
     const invalidIds: string[] = [];
     for (const course of catalogue) {
       try {
@@ -63,8 +62,6 @@ export const catalogueService: CatalogueService = {
         invalidIds.push(course.course_id);
       }
     }
-    console.log(`Invalid IDs: ${invalidIds.join(", ")}`);
-    console.log(`Invalid count: ${invalidIds.length}`);
 
     if (invalidIds.length > 0) {
       await this.deleteCourses(invalidIds);
@@ -79,7 +76,6 @@ export const catalogueService: CatalogueService = {
         console.error("Error deleting courses:", error);
         throw error;
       }
-      console.log(`Successfully deleted ${courseIds.length} courses`);
     } catch (error) {
       console.error("Error in deleteCourses:", error);
       throw error;

--- a/src/lib/ui/components/NotFound.svelte
+++ b/src/lib/ui/components/NotFound.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-
   interface Props {
     params: Record<string, string> | null;
   }
   let { params }: Props = $props();
-
-  onMount(() => {
-    console.log(params);
-  });
 </script>
 
 <h1>Not Found</h1>

--- a/src/lib/ui/learning-objects/content/TalkAdobe.svelte
+++ b/src/lib/ui/learning-objects/content/TalkAdobe.svelte
@@ -64,7 +64,6 @@
   }
 
   $effect(() => {
-    console.log(page.data?.lo?.pdf);
     if (mounted && page.data?.lo?.pdf) {
       displayPDF();
     }


### PR DESCRIPTION
## Summary

- Removes 4 debug `console.log` calls left from development:
  - `NotFound.svelte` — logged route params on mount (removed unused `onMount` import too)
  - `TalkAdobe.svelte` — logged PDF URL inside `$effect`
  - `catalogue.ts` — logged total course count, invalid IDs, invalid count, and deletion success in `pruneCatalogue`/`deleteCourses`
- Existing `console.error` calls in catch blocks are intentionally left — they serve as runtime error reporting

## Test plan

- [ ] Visit a non-existent route — "Not Found" page still renders
- [ ] Open a PDF talk — Adobe viewer still loads
- [ ] Catalogue page still loads course list

🤖 Generated with [Claude Code](https://claude.com/claude-code)