### PR TITLE
Migrate last on:click to Svelte 5 onclick syntax

### DIFF
--- a/src/lib/ui/navigators/buttons/SearchButton.svelte
+++ b/src/lib/ui/navigators/buttons/SearchButton.svelte
@@ -45,7 +45,7 @@
   updateSearchState();
 </script>
 
-<button on:click={toggleSearch}>
+<button onclick={toggleSearch}>
   <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
     <Icon type="search" tip="Search this course" />
     <span class="hidden lg:block"> {isSearching ? "Exit Search" : "Search"}</span>


### PR DESCRIPTION
## Summary

- Migrates the last remaining Svelte 4 `on:click` directive to Svelte 5 `onclick` in `SearchButton.svelte`
- The rest of the codebase already uses the Svelte 5 event syntax

## Test plan

- [ ] Click the search button in the course reader nav — search page opens
- [ ] Click again — returns to previous page

🤖 Generated with [Claude Code](https://claude.com/claude-code)