### PR TITLE
Add meaningful alt text to images with empty alt attributes

### DIFF
--- a/src/lib/ui/learning-objects/layout/Card.svelte
+++ b/src/lib/ui/learning-objects/layout/Card.svelte
@@ -72,7 +72,7 @@
       {#if cardDetails.student}
         <div class="flex items-center justify-between">
           <span>
-            <img src={cardDetails.img} alt="" class="rounded-xl {styles.avatar}" />
+            <img src={cardDetails.img} alt={cardDetails.student?.fullName ?? cardDetails.student?.id ?? ""} class="rounded-xl {styles.avatar}" />
           </span>
           <span>
             <h6 class={styles.text}>&nbsp;{cardDetails.student.fullName ?? cardDetails.student.id}</h6>
@@ -93,7 +93,7 @@
     {:else if cardDetails.icon}
       <Iconify icon={cardDetails.icon.type} color={cardDetails.icon.color} height={styles.icon} />
     {:else}
-      <img src={cardDetails.img} alt="" class="{styles.image} object-contain object-center {isCircular ? 'rounded-full' : ''}" />
+      <img src={cardDetails.img} alt={cardDetails.title} class="{styles.image} object-contain object-center {isCircular ? 'rounded-full' : ''}" />
     {/if}
   </figure>
 {/snippet}

--- a/src/lib/ui/time/StudentCard.svelte
+++ b/src/lib/ui/time/StudentCard.svelte
@@ -98,7 +98,7 @@
         {#if lo.img}
           <img
             src={lo.img}
-            alt=""
+            alt={lo.title}
             class="{styles.image} max-h-full w-full object-contain object-center rounded-xl"
           />
         {:else if lo.icon}


### PR DESCRIPTION
## Summary

- Replaces 3 empty `alt=""` attributes with descriptive text for screen readers:
  - `Card.svelte:75` — student avatar now uses student name as alt text
  - `Card.svelte:96` — card image now uses card title as alt text
  - `StudentCard.svelte:101` — learning object image now uses LO title as alt text

## Test plan

- [ ] View course cards in all three layout modes (portrait, landscape, circular) — images render correctly
- [ ] View student cards on the time page — avatar and LO images render correctly
- [ ] Inspect images with browser DevTools — alt attributes contain meaningful text

🤖 Generated with [Claude Code](https://claude.com/claude-code)