### PR TITLE
Fix Marp slide rendering hang

### DIFF
--- a/src/lib/services/markdown/services/marp-renderer.ts
+++ b/src/lib/services/markdown/services/marp-renderer.ts
@@ -11,11 +11,13 @@ export function isMarpContent(lo: Lo): boolean {
 }
 
 export async function renderMarpSlides(markdown: string): Promise<{ html: string; css: string }> {
-  const { Marp } = await import("@marp-team/marp-core");
-  const marp = new Marp({
-    container: { tag: "div", class: "marp-slides" },
-    html: true
+  const response = await fetch("/api/marp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ markdown })
   });
-  const { html, css } = marp.render(markdown);
-  return { html, css };
+  if (!response.ok) {
+    throw new Error(`Marp render failed: ${response.status}`);
+  }
+  return response.json();
 }

--- a/src/lib/ui/learning-objects/content/TalkMarp.svelte
+++ b/src/lib/ui/learning-objects/content/TalkMarp.svelte
@@ -13,6 +13,7 @@
   let { lo }: Props = $props();
 
   let loading = $state(true);
+  let error = $state("");
   let slideIndex = $state(0);
   let slideElements: string[] = $state([]);
   let marpCss = $state("");
@@ -34,13 +35,21 @@
     try {
       const { html, css } = await renderMarpSlides(lo.contentMd);
       marpCss = css;
+
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, "text/html");
-      const sections = doc.querySelectorAll("section");
-      slideElements = Array.from(sections).map((s) => s.outerHTML);
+
+      const svgs = doc.querySelectorAll("svg[data-marpit-svg]");
+      if (svgs.length > 0) {
+        slideElements = Array.from(svgs).map((svg) => svg.outerHTML);
+      } else {
+        const sections = doc.querySelectorAll("section");
+        slideElements = Array.from(sections).map((s) => s.outerHTML);
+      }
       loading = false;
-    } catch (error) {
-      console.error("Error rendering Marp slides:", error);
+    } catch (e) {
+      console.error("Error rendering Marp slides:", e);
+      error = e instanceof Error ? e.message : "Failed to render slides";
       loading = false;
     }
   }
@@ -73,13 +82,17 @@
 </script>
 
 <svelte:head>
-  {@html `<style>${marpCss}</style>`}
+  {#if marpCss}
+    {@html `<style>${marpCss}</style>`}
+  {/if}
 </svelte:head>
 
 <div class="card mr-2 rounded-lg border p-2">
   <div class="mx-2 mb-2 flex items-center justify-between">
     <div class="text-sm">
-      {slideIndex + 1} of {totalSlides}
+      {#if totalSlides > 0}
+        {slideIndex + 1} of {totalSlides}
+      {/if}
     </div>
     <div>
       <button class="btn btn-sm" onclick={prevSlide}>
@@ -97,6 +110,10 @@
   {#if loading}
     <div class="mt-72 mb-72 flex flex-col items-center justify-center">
       <Progress value={null} />
+    </div>
+  {:else if error}
+    <div class="flex items-center justify-center p-8 text-sm text-red-500">
+      {error}
     </div>
   {:else if totalSlides === 0}
     <div class="flex items-center justify-center p-8 text-sm opacity-60">
@@ -131,6 +148,11 @@
   :global(.marp-viewport .marp-slides) {
     width: 100%;
     height: 100%;
+  }
+  :global(.marp-viewport svg[data-marpit-svg]) {
+    width: 100%;
+    height: 100%;
+    display: block;
   }
   :global(.marp-viewport section) {
     width: 100% !important;

--- a/src/routes/api/marp/+server.ts
+++ b/src/routes/api/marp/+server.ts
@@ -1,0 +1,17 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { Marp } from "@marp-team/marp-core";
+
+const marp = new Marp({
+  container: { tag: "div", class: "marp-slides" },
+  html: true
+});
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { markdown } = await request.json();
+  if (!markdown) {
+    return json({ error: "No markdown provided" }, { status: 400 });
+  }
+  const { html, css } = marp.render(markdown);
+  return json({ html, css });
+};


### PR DESCRIPTION
## Summary

- **Root cause**: `@marp-team/marp-core` depends on PostCSS (Node.js-only), so the browser-side `await import("@marp-team/marp-core")` in `marp-renderer.ts` hangs indefinitely — PostCSS cannot run in a browser environment.
- **Fix**: Move Marp rendering to a SvelteKit server-side API endpoint (`POST /api/marp`). The client sends markdown to the endpoint, which runs `Marp.render()` server-side where PostCSS works, and returns the HTML + CSS.
- **Also fixed**: Marp Core wraps each slide in `<svg data-marpit-svg>` elements (not plain `<section>` tags). Updated TalkMarp to extract slides from these SVG wrappers. Added error state display so rendering failures show a message instead of hanging.

### Changes
- `src/routes/api/marp/+server.ts` — **New** server endpoint for Marp rendering
- `src/lib/services/markdown/services/marp-renderer.ts` — Switch from browser-side dynamic import to `fetch("/api/marp")`
- `src/lib/ui/learning-objects/content/TalkMarp.svelte` — Parse SVG slides, add error state, guard empty CSS injection

## Test plan
- [ ] Load a talk with `marp: true` frontmatter — verify slides render (no more hanging spinner)
- [ ] Navigate slides with arrow keys and buttons
- [ ] Test fullscreen toggle
- [ ] Verify existing PDF talks still render normally
- [ ] Verify mermaid diagrams in notes/labs still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)