### PR TITLE
feat: extend testing infrastructure with unit tests, E2E, and Zod contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ vite.config.ts.timestamp-*
 coverage/
 playwright-report/
 .stryker-tmp/
+.stryker-cache/
 test-results/
+reports/

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.16",
-        "vitest": "^3.2.7"
+        "vitest": "^3.2.7",
+        "zod": "^3.25.67"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -203,6 +204,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -788,35 +790,13 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1917,6 +1897,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2116,6 +2097,7 @@
       "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-3.2.2.tgz",
       "integrity": "sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "cssesc": "^3.0.0",
@@ -4120,6 +4102,7 @@
       "integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -4179,6 +4162,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -5013,6 +4997,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5040,6 +5025,7 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -5119,6 +5105,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -5226,6 +5213,7 @@
       "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5327,6 +5315,7 @@
       "integrity": "sha512-gIzazUkbQfv6T1rJHOLhMMKQnplKAvvQ7QNGaFwI6oCsp4z2aSDZCojGpX3QX3+MYsvJdyy/8BRIYVEbAkMkEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5497,6 +5486,7 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -6154,6 +6144,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6398,6 +6389,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6838,6 +6830,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7259,6 +7252,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7620,6 +7614,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7684,6 +7679,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8433,6 +8429,7 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -9724,6 +9721,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -10229,6 +10227,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/mutation-server-protocol/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/mutation-testing-elements": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
@@ -10696,6 +10704,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -10821,6 +10830,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10910,6 +10920,7 @@
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10941,6 +10952,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10957,6 +10969,7 @@
       "integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -11881,6 +11894,7 @@
       "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12039,7 +12053,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -12308,6 +12323,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12552,6 +12568,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12748,6 +12765,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",
@@ -13256,9 +13274,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:changed": "vitest related --run",
     "test:mutation": "stryker run",
     "test:mutation:incremental": "stryker run --incremental",
+    "test:smoke": "playwright test --project smoke",
     "test:all": "npm run test:unit && npm run test:e2e"
   },
   "devDependencies": {
@@ -77,7 +78,8 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "zod": "^3.25.67"
   },
   "dependencies": {
     "@marp-team/marp-core": "^4.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
 
   projects: [
     {
+      name: 'smoke',
+      testMatch: /smoke\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] }
     },
@@ -39,6 +44,12 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120000
+    timeout: 120000,
+    env: {
+      PUBLIC_ANON_MODE: 'TRUE',
+      PRIVATE_AUTH_SECRET: 'test-secret',
+      PRIVATE_AUTH_GITHUB_ID: 'test-github-id',
+      PRIVATE_AUTH_GITHUB_SECRET: 'test-github-secret'
+    }
   }
 });

--- a/tests/contracts/schemas.ts
+++ b/tests/contracts/schemas.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+
+export const IconTypeSchema = z.object({
+  type: z.string(),
+  color: z.string()
+});
+
+export const CourseSentimentIdSchema = z.enum(["neutral", "fine", "delighted", "confident", "overwhelmed", "confused", "drained"]);
+
+export const TutorsIdSchema = z.object({
+  name: z.string(),
+  login: z.string(),
+  email: z.string(),
+  image: z.string(),
+  share: z.string(),
+  sentiment: z.string()
+});
+
+export const CourseVisitSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  img: z.string().optional(),
+  icon: IconTypeSchema.optional(),
+  lastVisit: z.coerce.date(),
+  credits: z.string(),
+  visits: z.number().int().positive().optional(),
+  private: z.boolean().optional(),
+  favourite: z.boolean().optional()
+});
+
+export const LoUserSchema = z.object({
+  fullName: z.string(),
+  avatar: z.string(),
+  id: z.string(),
+  sentiment: z.string()
+});
+
+export const LoRecordSchema = z.object({
+  courseId: z.string(),
+  courseUrl: z.string(),
+  courseTitle: z.string(),
+  loRoute: z.string(),
+  title: z.string(),
+  img: z.string().optional(),
+  icon: IconTypeSchema.optional(),
+  isPrivate: z.boolean(),
+  user: LoUserSchema.optional(),
+  type: z.string()
+});
+
+export const TutorsConnectLatestRowSchema = z.object({
+  course_id: z.string(),
+  student_id: z.string(),
+  payload: z.record(z.unknown()),
+  received_at: z.string()
+});
+
+export const CatalogueEntrySchema = z.object({
+  course_id: z.string(),
+  visited_at: z.coerce.date(),
+  visit_count: z.number().int().nonnegative(),
+  course_record: z.any()
+});
+
+export const LayoutTypeSchema = z.enum(["expanded", "compacted"]);
+export const CardStyleTypeSchema = z.enum(["portrait", "landscape", "circular"]);
+
+export const ThemeSchema = z.object({
+  name: z.string(),
+  icons: z.record(IconTypeSchema)
+});
+
+export const CardDetailsSchema = z.object({
+  route: z.string(),
+  title: z.string().optional(),
+  type: z.string(),
+  summary: z.string().optional(),
+  summaryEx: z.string().optional(),
+  icon: IconTypeSchema.optional(),
+  img: z.string().optional(),
+  student: LoUserSchema.optional(),
+  video: z.string().optional(),
+  metric: z.string().optional()
+});
+
+export const LoSchema: z.ZodType = z.object({
+  route: z.string(),
+  type: z.string(),
+  title: z.string(),
+  shortTitle: z.string().optional(),
+  summary: z.string().optional(),
+  contentMd: z.string().optional(),
+  contentHtml: z.string().optional(),
+  img: z.string().optional(),
+  video: z.string().optional(),
+  icon: IconTypeSchema.optional(),
+  breadCrumbs: z.array(z.any()).optional(),
+  parentLo: z.any().optional(),
+  parentCourse: z.any().optional(),
+  los: z.array(z.any()).optional()
+});
+
+export const LabStepSchema = z.object({
+  shortTitle: z.string(),
+  title: z.string(),
+  contentMd: z.string().optional(),
+  contentHtml: z.string().optional(),
+  type: z.string()
+});
+
+export const LabSchema = LoSchema.extend({
+  type: z.literal("lab"),
+  los: z.array(LabStepSchema),
+  pdf: z.string().optional()
+});
+
+export const CourseSchema = z.object({
+  courseId: z.string(),
+  courseUrl: z.string(),
+  title: z.string(),
+  img: z.string().optional(),
+  route: z.string(),
+  type: z.literal("course"),
+  los: z.array(LoSchema),
+  properties: z
+    .object({
+      credits: z.string().optional(),
+      icon: z.any().optional(),
+      private: z.any().optional()
+    })
+    .passthrough()
+    .optional(),
+  isPrivate: z.boolean().optional(),
+  areLabStepsAutoNumbered: z.boolean().optional(),
+  authLevel: z.number().optional(),
+  enrollment: z
+    .object({
+      whitelist: z.array(z.string()).optional()
+    })
+    .optional()
+});
+
+export const CourseUrlResultSchema = z.object({
+  courseId: z.string(),
+  courseUrl: z.string()
+});

--- a/tests/contracts/validators.ts
+++ b/tests/contracts/validators.ts
@@ -1,0 +1,15 @@
+import type { ZodSchema } from "zod";
+
+export function assertValid<T>(schema: ZodSchema<T>, data: unknown): T {
+  return schema.parse(data);
+}
+
+export function isValid<T>(schema: ZodSchema<T>, data: unknown): boolean {
+  return schema.safeParse(data).success;
+}
+
+export function validationErrors<T>(schema: ZodSchema<T>, data: unknown): string[] {
+  const result = schema.safeParse(data);
+  if (result.success) return [];
+  return result.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`);
+}

--- a/tests/e2e/course-reader.spec.ts
+++ b/tests/e2e/course-reader.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { interceptCourseRequests } from "./helpers/intercept-course";
+
+test.describe("Course Reader", () => {
+  test("loads a course and displays the title", async ({ page }) => {
+    await interceptCourseRequests(page, "test-course");
+    await page.goto("/course/test-course");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByRole("heading", { name: "Test Course" })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("displays topic cards for the course", async ({ page }) => {
+    await interceptCourseRequests(page, "test-course");
+    await page.goto("/course/test-course");
+    await page.waitForLoadState("networkidle");
+
+    const topicText = page.getByText("Topic 1");
+    await expect(topicText.first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/e2e/fixtures/mock-course.json
+++ b/tests/e2e/fixtures/mock-course.json
@@ -1,0 +1,87 @@
+{
+  "title": "Test Course",
+  "img": "https://{{COURSEURL}}/img/course.png",
+  "route": "/course/{{COURSEURL}}",
+  "type": "course",
+  "summary": "A test course for automated testing",
+  "contentMd": "",
+  "id": "test-course",
+  "hide": false,
+  "video": "",
+  "frontMatter": {},
+  "authLevel": 0,
+  "isPrivate": false,
+  "areLabStepsAutoNumbered": false,
+  "properties": {
+    "credits": "Test Author",
+    "icon": null,
+    "private": 0
+  },
+  "los": [
+    {
+      "title": "Topic 1",
+      "type": "topic",
+      "shortTitle": "topic-01",
+      "route": "/topic/{{COURSEURL}}/topic-01",
+      "img": "https://{{COURSEURL}}/img/topic1.png",
+      "summary": "First topic",
+      "contentMd": "",
+      "contentHtml": "<p>Topic 1 content</p>",
+      "id": "topic-01",
+      "hide": false,
+      "video": "",
+      "frontMatter": {},
+      "los": [
+        {
+          "title": "Lab 1",
+          "type": "lab",
+          "shortTitle": "lab-01",
+          "route": "/lab/{{COURSEURL}}/topic-01/lab-01",
+          "img": "https://{{COURSEURL}}/img/lab1.png",
+          "summary": "First lab",
+          "contentMd": "",
+          "id": "lab-01",
+          "hide": false,
+          "video": "",
+          "frontMatter": {},
+          "los": [
+            {
+              "shortTitle": "Step01",
+              "title": "# Introduction",
+              "contentMd": "## Welcome\nThis is step 1.",
+              "contentHtml": "<h2>Welcome</h2><p>This is step 1.</p>",
+              "type": "step",
+              "id": "step-01",
+              "route": "/lab/{{COURSEURL}}/topic-01/lab-01/Step01"
+            },
+            {
+              "shortTitle": "Step02",
+              "title": "# Exercise",
+              "contentMd": "## Task\nComplete this exercise.",
+              "contentHtml": "<h2>Task</h2><p>Complete this exercise.</p>",
+              "type": "step",
+              "id": "step-02",
+              "route": "/lab/{{COURSEURL}}/topic-01/lab-01/Step02"
+            }
+          ]
+        },
+        {
+          "title": "Talk 1",
+          "type": "talk",
+          "shortTitle": "talk-01",
+          "route": "/talk/{{COURSEURL}}/topic-01/talk-01",
+          "img": "https://{{COURSEURL}}/img/talk1.png",
+          "summary": "First talk",
+          "contentMd": "",
+          "contentHtml": "<p>Talk content</p>",
+          "id": "talk-01",
+          "hide": false,
+          "video": "",
+          "frontMatter": {},
+          "pdf": "https://{{COURSEURL}}/topic-01/talk-01/talk-01.pdf",
+          "los": []
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/helpers/intercept-course.ts
+++ b/tests/e2e/helpers/intercept-course.ts
@@ -1,0 +1,28 @@
+import { type Page } from "@playwright/test";
+import mockCourse from "../fixtures/mock-course.json" with { type: "json" };
+
+export function injectCourseUrl(obj: unknown, courseUrl: string): unknown {
+  const json = JSON.stringify(obj);
+  return JSON.parse(json.replaceAll("{{COURSEURL}}", courseUrl));
+}
+
+export async function interceptCourseRequests(page: Page, courseId: string) {
+  const courseUrl = `${courseId}.netlify.app`;
+  const courseData = injectCourseUrl(mockCourse, courseUrl);
+
+  await page.route(`**/${courseUrl}/tutors.json`, (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(courseData) })
+  );
+
+  await page.route(`**/${courseUrl}/img/**`, (route) =>
+    route.fulfill({ status: 200, contentType: "image/png", body: Buffer.from([]) })
+  );
+
+  await page.route("**/*.supabase.co/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ data: [], error: null }) })
+  );
+
+  await page.route("**/partykit/**", (route) => route.abort());
+
+  return courseData;
+}

--- a/tests/e2e/lab-navigation.spec.ts
+++ b/tests/e2e/lab-navigation.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+import { interceptCourseRequests } from "./helpers/intercept-course";
+
+test.describe("Lab Navigation", () => {
+  test("lab page loads with step content", async ({ page }) => {
+    await interceptCourseRequests(page, "test-course");
+    await page.goto("/lab/test-course/topic-01/lab-01");
+    await page.waitForLoadState("networkidle");
+
+    const content = await page.locator("body").textContent();
+    expect(content?.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Smoke Tests", () => {
+  test("homepage loads without errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test("homepage has content", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const body = await page.locator("body").textContent();
+    expect(body?.trim().length).toBeGreaterThan(0);
+  });
+
+  test("auth page loads", async ({ page }) => {
+    await page.goto("/auth");
+    await page.waitForLoadState("networkidle");
+
+    const body = await page.locator("body").textContent();
+    expect(body?.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Theme", () => {
+  test("dark mode class is applied when set in localStorage", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      localStorage.setItem("modeCurrent", "dark");
+    });
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark")
+    );
+
+    expect(hasDark).toBe(true);
+  });
+});

--- a/tests/fixtures/course-factory.ts
+++ b/tests/fixtures/course-factory.ts
@@ -1,0 +1,131 @@
+let counter = 0;
+
+export function createCourse(overrides: Record<string, any> = {}) {
+  counter++;
+  return {
+    courseId: `test-course-${counter}`,
+    courseUrl: `test-course-${counter}.netlify.app`,
+    title: `Test Course ${counter}`,
+    img: `https://test-course-${counter}.netlify.app/img/course.png`,
+    route: `/course/test-course-${counter}`,
+    type: "course" as const,
+    summary: "",
+    contentMd: "",
+    contentHtml: "",
+    id: `test-course-${counter}`,
+    los: [],
+    loIndex: new Map(),
+    topicIndex: new Map(),
+    wallMap: new Map(),
+    properties: { credits: "Test Author" },
+    isPrivate: false,
+    areLabStepsAutoNumbered: false,
+    authLevel: 0,
+    frontMatter: {},
+    hide: false,
+    video: "",
+    videoids: { videoid: "", videoIds: [] },
+    imgFile: "",
+    isPortfolio: false,
+    llm: 0,
+    pdfOrientation: "landscape",
+    areVideosHidden: false,
+    hasEnrollment: false,
+    hasCalendar: false,
+    defaultPdfReader: "mozilla",
+    footer: "",
+    ignorePin: "",
+    companions: { show: false, bar: [] },
+    wallBar: { show: false, bar: [] },
+    toc: [],
+    panels: { panelVideos: [], panelTalks: [], panelNotes: [], panelPodcasts: [] },
+    units: { units: [], sides: [], standardLos: [] },
+    ...overrides
+  };
+}
+
+export function createMinimalTutorsJson() {
+  return {
+    title: "Test Course",
+    img: "https://{{COURSEURL}}/img/course.png",
+    route: "/course/{{COURSEURL}}",
+    type: "course" as const,
+    summary: "A test course",
+    contentMd: "",
+    id: "test-course",
+    hide: false,
+    video: "",
+    frontMatter: {},
+    los: [
+      {
+        title: "Topic 1",
+        type: "topic",
+        shortTitle: "topic-01",
+        route: "/topic/{{COURSEURL}}/topic-01",
+        img: "https://{{COURSEURL}}/img/topic1.png",
+        summary: "First topic",
+        contentMd: "",
+        contentHtml: "",
+        id: "topic-01",
+        hide: false,
+        video: "",
+        frontMatter: {},
+        los: [
+          {
+            title: "Lab 1",
+            type: "lab",
+            shortTitle: "lab-01",
+            route: "/lab/{{COURSEURL}}/topic-01/lab-01",
+            summary: "First lab",
+            contentMd: "",
+            id: "lab-01",
+            hide: false,
+            video: "",
+            frontMatter: {},
+            los: [
+              {
+                shortTitle: "Step01",
+                title: "# Introduction",
+                contentMd: "## Welcome\nThis is step 1.",
+                contentHtml: "<h2>Welcome</h2><p>This is step 1.</p>",
+                type: "step",
+                id: "step-01"
+              },
+              {
+                shortTitle: "Step02",
+                title: "# Exercise",
+                contentMd: "## Task\nComplete this.",
+                contentHtml: "<h2>Task</h2><p>Complete this.</p>",
+                type: "step",
+                id: "step-02"
+              }
+            ]
+          },
+          {
+            title: "Talk 1",
+            type: "talk",
+            shortTitle: "talk-01",
+            route: "/talk/{{COURSEURL}}/topic-01/talk-01",
+            summary: "First talk",
+            contentMd: "",
+            id: "talk-01",
+            hide: false,
+            video: "",
+            frontMatter: {},
+            pdf: "https://{{COURSEURL}}/topic-01/talk-01/talk-01.pdf",
+            los: []
+          }
+        ]
+      }
+    ],
+    properties: {
+      credits: "Test Author",
+      icon: null,
+      private: 0
+    }
+  };
+}
+
+export function resetCourseCounter() {
+  counter = 0;
+}

--- a/tests/fixtures/lo-factory.ts
+++ b/tests/fixtures/lo-factory.ts
@@ -1,0 +1,62 @@
+export function createLo(overrides: Record<string, any> = {}) {
+  return {
+    route: "/topic/test-course/topic-01",
+    type: "topic",
+    title: "Test Topic",
+    shortTitle: "topic-01",
+    summary: "A test topic",
+    contentMd: "",
+    contentHtml: "",
+    img: "https://test-course.netlify.app/img/topic.png",
+    video: "",
+    hide: false,
+    id: "topic-01",
+    frontMatter: {},
+    breadCrumbs: [],
+    los: [],
+    ...overrides
+  };
+}
+
+export function createLabWithSteps(stepTitles: string[]) {
+  return {
+    type: "lab",
+    title: "Test Lab",
+    shortTitle: "lab-01",
+    route: "/lab/test-course/lab-01",
+    summary: "A test lab",
+    contentMd: "",
+    id: "lab-01",
+    hide: false,
+    video: "",
+    frontMatter: {},
+    los: stepTitles.map((title, i) => ({
+      shortTitle: `Step${String(i + 1).padStart(2, "0")}`,
+      title: `# ${title}`,
+      contentMd: `Content for ${title}`,
+      contentHtml: `<p>Content for ${title}</p>`,
+      type: "step",
+      id: `step-${i + 1}`
+    }))
+  };
+}
+
+export function createLoRecord(overrides: Record<string, any> = {}) {
+  return {
+    courseId: "test-course",
+    courseUrl: "test-course.netlify.app",
+    courseTitle: "Test Course",
+    loRoute: "/lab/test-course/lab-01",
+    title: "Lab 1",
+    img: "https://test-course.netlify.app/img/lab.png",
+    isPrivate: false,
+    type: "lab",
+    user: {
+      fullName: "Test User",
+      avatar: "https://avatars.example.com/1.png",
+      id: "testuser1",
+      sentiment: "neutral"
+    },
+    ...overrides
+  };
+}

--- a/tests/fixtures/user-factory.ts
+++ b/tests/fixtures/user-factory.ts
@@ -1,0 +1,35 @@
+import { TutorsIdSchema, LoUserSchema } from "../contracts/schemas";
+
+let counter = 0;
+
+export function createTutorsId(overrides: Record<string, any> = {}) {
+  counter++;
+  const user = {
+    name: `Test User ${counter}`,
+    login: `testuser${counter}`,
+    email: `testuser${counter}@example.com`,
+    image: `https://avatars.example.com/${counter}.png`,
+    share: "true",
+    sentiment: "neutral",
+    ...overrides
+  };
+  TutorsIdSchema.parse(user);
+  return user;
+}
+
+export function createLoUser(overrides: Record<string, any> = {}) {
+  counter++;
+  const user = {
+    fullName: `Test User ${counter}`,
+    avatar: `https://avatars.example.com/${counter}.png`,
+    id: `testuser${counter}`,
+    sentiment: "neutral",
+    ...overrides
+  };
+  LoUserSchema.parse(user);
+  return user;
+}
+
+export function resetUserCounter() {
+  counter = 0;
+}

--- a/tests/mocks/env-private.ts
+++ b/tests/mocks/env-private.ts
@@ -1,0 +1,3 @@
+export const PRIVATE_AUTH_GITHUB_ID = "test-github-id";
+export const PRIVATE_AUTH_GITHUB_SECRET = "test-github-secret";
+export const PRIVATE_AUTH_SECRET = "test-auth-secret";

--- a/tests/mocks/env-public.ts
+++ b/tests/mocks/env-public.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_ANON_MODE = "TRUE";
+export const PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+export const PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+export const PUBLIC_party_kit_main_room = "localhost:1999";
+export const PUBLIC_PDF_KEY = "test-pdf-key";

--- a/tests/mocks/sveltekit-modules.ts
+++ b/tests/mocks/sveltekit-modules.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+
+export const browser = true;
+export const dev = false;
+export const building = false;
+
+export const goto = vi.fn();
+export const afterNavigate = vi.fn();
+export const beforeNavigate = vi.fn();
+export const invalidate = vi.fn();
+export const invalidateAll = vi.fn();
+
+export const page = {
+  params: {},
+  url: new URL("http://localhost"),
+  route: { id: "" }
+};

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -26,15 +26,28 @@ beforeAll(() => {
     version: "test"
   }));
 
-  // Mock localStorage
-  const localStorageMock: Storage = {
-    length: 0,
-    key: vi.fn(),
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn()
-  };
+  // Proxy-based localStorage mock supports both standard API and direct property access
+  // (e.g. localStorage.courseVisits = "..." which the source code uses)
+  const store: Record<string, string> = {};
+  const API_KEYS = new Set(["getItem", "setItem", "removeItem", "clear", "length", "key"]);
+  const localStorageMock = new Proxy(
+    {
+      getItem(key: string) { return store[key] ?? null; },
+      setItem(key: string, value: string) { store[key] = String(value); },
+      removeItem(key: string) { delete store[key]; },
+      clear() { for (const key of Object.keys(store)) delete store[key]; },
+      get length() { return Object.keys(store).length; },
+      key(index: number) { return Object.keys(store)[index] ?? null; }
+    },
+    {
+      get(target: any, prop: string) {
+        if (API_KEYS.has(prop)) return typeof target[prop] === "function" ? target[prop].bind(target) : target[prop];
+        return store[prop] ?? undefined;
+      },
+      set(_target: any, prop: string, value: string) { store[prop] = String(value); return true; },
+      deleteProperty(_target: any, prop: string) { delete store[prop]; return true; }
+    }
+  );
 
   Object.defineProperty(window, "localStorage", {
     value: localStorageMock,
@@ -63,6 +76,13 @@ beforeAll(() => {
       dispatchEvent: vi.fn()
     }))
   });
+
+  // Spies for theme-related DOM mutations
+  if (typeof document !== "undefined") {
+    vi.spyOn(document.documentElement.classList, "add");
+    vi.spyOn(document.documentElement.classList, "remove");
+    vi.spyOn(document.documentElement, "setAttribute");
+  }
 });
 
 afterEach(() => {

--- a/tests/unit/services/community/presence-service.test.ts
+++ b/tests/unit/services/community/presence-service.test.ts
@@ -1,0 +1,114 @@
+vi.mock("partysocket", () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      send: vi.fn(),
+      addEventListener: vi.fn(),
+      close: vi.fn()
+    }))
+  };
+});
+
+vi.mock("$lib/services/community/utils/supabase-client", () => ({
+  upsertTutorsConnectLatestLo: vi.fn()
+}));
+
+vi.mock("$lib/runes.svelte", () => {
+  const rune = <T>(initial: T) => {
+    let value = initial;
+    return {
+      get value() { return value; },
+      set value(v: T) { value = v; }
+    };
+  };
+  return {
+    rune,
+    tutorsId: rune(null),
+    currentLo: rune(null),
+    currentCourse: rune(null),
+    currentLabStepIndex: rune(0),
+    adobeLoaded: rune(false),
+    animationDelay: rune(200),
+    courseProtocol: rune("https://"),
+    hideMainNavigator: rune(false)
+  };
+});
+
+const { refreshLoRecord } = await import("$lib/services/community/services/presence.svelte");
+
+describe("refreshLoRecord", () => {
+  it("updates loRoute with tutors.dev prefix", () => {
+    const existing: any = {
+      courseId: "c1",
+      courseUrl: "c1.netlify.app",
+      courseTitle: "Course 1",
+      loRoute: "/lab/c1/lab-01",
+      title: "Lab 1",
+      img: "img1.png",
+      isPrivate: false,
+      type: "lab",
+      user: { fullName: "User", avatar: "a.png", id: "u1", sentiment: "neutral" }
+    };
+
+    const next: any = {
+      courseId: "c1",
+      courseUrl: "c1.netlify.app",
+      courseTitle: "Course 1",
+      loRoute: "/talk/c1/talk-01",
+      title: "Talk 1",
+      img: "img2.png",
+      isPrivate: false,
+      type: "talk",
+      user: { fullName: "User", avatar: "a.png", id: "u1", sentiment: "fine" }
+    };
+
+    refreshLoRecord(existing, next);
+    expect(existing.loRoute).toBe("https://tutors.dev/talk/c1/talk-01");
+  });
+
+  it("updates title and type", () => {
+    const existing: any = {
+      loRoute: "/a", title: "Old", type: "lab",
+      user: null, img: "x.png"
+    };
+    const next: any = {
+      loRoute: "/b", title: "New", type: "talk",
+      user: { fullName: "U", avatar: "a.png", id: "u1", sentiment: "neutral" },
+      img: "y.png"
+    };
+
+    refreshLoRecord(existing, next);
+    expect(existing.title).toBe("New");
+    expect(existing.type).toBe("talk");
+  });
+
+  it("updates user reference", () => {
+    const existing: any = { loRoute: "/a", title: "X", type: "lab", user: null, img: "x.png" };
+    const newUser = { fullName: "New User", avatar: "new.png", id: "u2", sentiment: "delighted" };
+    const next: any = { loRoute: "/b", title: "Y", type: "lab", user: newUser, img: "x.png" };
+
+    refreshLoRecord(existing, next);
+    expect(existing.user).toBe(newUser);
+  });
+
+  it("sets icon and clears img when next has icon", () => {
+    const existing: any = { loRoute: "/a", title: "X", type: "lab", user: null, img: "x.png" };
+    const icon = { type: "fluent", color: "primary" };
+    const next: any = { loRoute: "/b", title: "Y", type: "lab", user: null, icon, img: undefined };
+
+    refreshLoRecord(existing, next);
+    expect(existing.icon).toBe(icon);
+    expect(existing.img).toBeUndefined();
+  });
+
+  it("sets img and clears icon when next has no icon", () => {
+    const existing: any = {
+      loRoute: "/a", title: "X", type: "lab", user: null,
+      icon: { type: "fluent", color: "primary" }
+    };
+    const next: any = { loRoute: "/b", title: "Y", type: "lab", user: null, img: "new.png" };
+
+    refreshLoRecord(existing, next);
+    expect(existing.img).toBe("new.png");
+    expect(existing.icon).toBeUndefined();
+  });
+});

--- a/tests/unit/services/community/supabase-client.test.ts
+++ b/tests/unit/services/community/supabase-client.test.ts
@@ -1,0 +1,167 @@
+import {
+  localYyyyMmDd,
+  instantLocalYmd,
+  isReceivedAtOnLocalDay,
+  isReceivedAtInLocalWeek,
+  isReceivedAtInLocalMonth,
+  isReceivedAtInLocalYear,
+  formatDate
+} from "$lib/services/community/utils/supabase-client";
+
+describe("supabase-client date utilities", () => {
+  describe("localYyyyMmDd", () => {
+    it("formats a date as YYYY-MM-DD", () => {
+      const d = new Date(2025, 0, 5);
+      expect(localYyyyMmDd(d)).toBe("2025-01-05");
+    });
+
+    it("pads single-digit months and days", () => {
+      const d = new Date(2025, 2, 3);
+      expect(localYyyyMmDd(d)).toBe("2025-03-03");
+    });
+
+    it("handles December correctly", () => {
+      const d = new Date(2025, 11, 25);
+      expect(localYyyyMmDd(d)).toBe("2025-12-25");
+    });
+
+    it("defaults to current date when no argument given", () => {
+      const result = localYyyyMmDd();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe("instantLocalYmd", () => {
+    it("converts an ISO string to local YYYY-MM-DD", () => {
+      const result = instantLocalYmd("2025-06-15T10:30:00Z");
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("returns null for null input", () => {
+      expect(instantLocalYmd(null)).toBeNull();
+    });
+
+    it("returns null for undefined input", () => {
+      expect(instantLocalYmd(undefined)).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(instantLocalYmd("")).toBeNull();
+    });
+
+    it("returns null for whitespace-only string", () => {
+      expect(instantLocalYmd("   ")).toBeNull();
+    });
+
+    it("returns null for invalid date string", () => {
+      expect(instantLocalYmd("not-a-date")).toBeNull();
+    });
+
+    it("trims whitespace from input", () => {
+      const result = instantLocalYmd("  2025-06-15T10:30:00Z  ");
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe("isReceivedAtOnLocalDay", () => {
+    it("returns true for same day", () => {
+      const ref = new Date(2025, 5, 15, 10, 0, 0);
+      const iso = new Date(2025, 5, 15, 14, 30, 0).toISOString();
+      expect(isReceivedAtOnLocalDay(iso, ref)).toBe(true);
+    });
+
+    it("returns false for different day", () => {
+      const ref = new Date(2025, 5, 15);
+      const iso = new Date(2025, 5, 16).toISOString();
+      expect(isReceivedAtOnLocalDay(iso, ref)).toBe(false);
+    });
+
+    it("returns false for null input", () => {
+      expect(isReceivedAtOnLocalDay(null)).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isReceivedAtOnLocalDay("")).toBe(false);
+    });
+  });
+
+  describe("isReceivedAtInLocalWeek", () => {
+    it("returns true for same Monday-Sunday week", () => {
+      // Wednesday June 18, 2025
+      const ref = new Date(2025, 5, 18);
+      // Monday June 16, 2025 (same week)
+      const iso = new Date(2025, 5, 16).toISOString();
+      expect(isReceivedAtInLocalWeek(iso, ref)).toBe(true);
+    });
+
+    it("returns false for different weeks", () => {
+      const ref = new Date(2025, 5, 18);
+      const iso = new Date(2025, 5, 9).toISOString();
+      expect(isReceivedAtInLocalWeek(iso, ref)).toBe(false);
+    });
+
+    it("returns false for null input", () => {
+      expect(isReceivedAtInLocalWeek(null)).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isReceivedAtInLocalWeek("")).toBe(false);
+    });
+
+    it("returns false for invalid date", () => {
+      expect(isReceivedAtInLocalWeek("not-a-date")).toBe(false);
+    });
+  });
+
+  describe("isReceivedAtInLocalMonth", () => {
+    it("returns true for same month", () => {
+      const ref = new Date(2025, 5, 15);
+      const iso = new Date(2025, 5, 1).toISOString();
+      expect(isReceivedAtInLocalMonth(iso, ref)).toBe(true);
+    });
+
+    it("returns false for different month", () => {
+      const ref = new Date(2025, 5, 15);
+      const iso = new Date(2025, 4, 15).toISOString();
+      expect(isReceivedAtInLocalMonth(iso, ref)).toBe(false);
+    });
+
+    it("returns false for null input", () => {
+      expect(isReceivedAtInLocalMonth(null)).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isReceivedAtInLocalMonth("")).toBe(false);
+    });
+  });
+
+  describe("isReceivedAtInLocalYear", () => {
+    it("returns true for same year", () => {
+      const ref = new Date(2025, 0, 1);
+      const iso = new Date(2025, 11, 31).toISOString();
+      expect(isReceivedAtInLocalYear(iso, ref)).toBe(true);
+    });
+
+    it("returns false for different year", () => {
+      const ref = new Date(2025, 5, 15);
+      const iso = new Date(2024, 5, 15).toISOString();
+      expect(isReceivedAtInLocalYear(iso, ref)).toBe(false);
+    });
+
+    it("returns false for null input", () => {
+      expect(isReceivedAtInLocalYear(null)).toBe(false);
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats a date as YYYY-MM-DD", () => {
+      const d = new Date(2025, 0, 5);
+      expect(formatDate(d)).toBe("2025-01-05");
+    });
+
+    it("pads single-digit months and days", () => {
+      const d = new Date(2025, 2, 3);
+      expect(formatDate(d)).toBe("2025-03-03");
+    });
+  });
+});

--- a/tests/unit/services/connect/localStorageProfile.test.ts
+++ b/tests/unit/services/connect/localStorageProfile.test.ts
@@ -1,0 +1,146 @@
+import { createCourse, resetCourseCounter } from "../../../fixtures/course-factory";
+
+vi.mock("$app/environment", () => ({ browser: true }));
+
+const { localStorageProfile } = await import("$lib/services/connect/services/localStorageProfile");
+
+describe("localStorageProfile", () => {
+  beforeEach(() => {
+    resetCourseCounter();
+    localStorage.clear();
+    localStorageProfile.courseVisits = [];
+  });
+
+  describe("logCourseVisit", () => {
+    it("adds a new course visit", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits).toHaveLength(1);
+      expect(localStorageProfile.courseVisits[0].id).toBe(course.courseId);
+    });
+
+    it("increments visit count for existing course", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits).toHaveLength(1);
+      expect(localStorageProfile.courseVisits[0].visits).toBe(2);
+    });
+
+    it("persists visits to localStorage", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      const stored = JSON.parse(localStorage.courseVisits);
+      expect(stored).toHaveLength(1);
+      expect(stored[0].id).toBe(course.courseId);
+    });
+
+    it("stores course title", () => {
+      const course = createCourse({ title: "My Course" }) as any;
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits[0].title).toBe("My Course");
+    });
+
+    it("stores course credits", () => {
+      const course = createCourse({ properties: { credits: "Author Name" } }) as any;
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits[0].credits).toBe("Author Name");
+    });
+
+    it("stores icon when course has one", () => {
+      const course = createCourse({
+        properties: { credits: "Author", icon: { type: "fluent", color: "primary" } }
+      }) as any;
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits[0].icon).toBeDefined();
+    });
+
+    it("stores img when course has no icon", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      expect(localStorageProfile.courseVisits[0].img).toBe(course.img);
+    });
+
+    it("adds new visits at the beginning of the array", () => {
+      const course1 = createCourse() as any;
+      const course2 = createCourse() as any;
+      localStorageProfile.logCourseVisit(course1);
+      localStorageProfile.logCourseVisit(course2);
+      expect(localStorageProfile.courseVisits[0].id).toBe(course2.courseId);
+    });
+  });
+
+  describe("deleteCourseVisit", () => {
+    it("removes a course visit by id", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      localStorageProfile.deleteCourseVisit(course.courseId);
+      expect(localStorageProfile.courseVisits).toHaveLength(0);
+    });
+
+    it("does not remove other course visits", () => {
+      const course1 = createCourse() as any;
+      const course2 = createCourse() as any;
+      localStorageProfile.logCourseVisit(course1);
+      localStorageProfile.logCourseVisit(course2);
+      localStorageProfile.deleteCourseVisit(course1.courseId);
+      expect(localStorageProfile.courseVisits).toHaveLength(1);
+      expect(localStorageProfile.courseVisits[0].id).toBe(course2.courseId);
+    });
+
+    it("updates localStorage after deletion", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      localStorageProfile.deleteCourseVisit(course.courseId);
+      const stored = JSON.parse(localStorage.courseVisits);
+      expect(stored).toHaveLength(0);
+    });
+  });
+
+  describe("getCourseVisits", () => {
+    it("returns empty array when no visits", () => {
+      const visits = localStorageProfile.getCourseVisits() as any;
+      expect(visits).toHaveLength(0);
+    });
+
+    it("returns visits after logging courses", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      const visits = localStorageProfile.getCourseVisits() as any;
+      expect(visits).toHaveLength(1);
+    });
+
+    it("reloads from localStorage", () => {
+      localStorage.courseVisits = JSON.stringify([
+        { id: "stored-course", title: "Stored", lastVisit: new Date(), credits: "Author", visits: 3 }
+      ]);
+      const visits = localStorageProfile.getCourseVisits() as any;
+      expect(visits).toHaveLength(1);
+      expect(visits[0].id).toBe("stored-course");
+    });
+  });
+
+  describe("favouriteCourse", () => {
+    it("marks a course as favourite", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      localStorageProfile.favouriteCourse(course.courseId);
+      expect(localStorageProfile.courseVisits[0].favourite).toBe(true);
+    });
+
+    it("does nothing for non-existent course", () => {
+      localStorageProfile.favouriteCourse("non-existent");
+      expect(localStorageProfile.courseVisits).toHaveLength(0);
+    });
+  });
+
+  describe("unfavouriteCourse", () => {
+    it("removes favourite status from a course", () => {
+      const course = createCourse() as any;
+      localStorageProfile.logCourseVisit(course);
+      localStorageProfile.favouriteCourse(course.courseId);
+      localStorageProfile.unfavouriteCourse(course.courseId);
+      expect(localStorageProfile.courseVisits[0].favourite).toBe(false);
+    });
+  });
+});

--- a/tests/unit/services/course/live-lab.test.ts
+++ b/tests/unit/services/course/live-lab.test.ts
@@ -1,0 +1,138 @@
+import { LiveLab } from "$lib/services/course/services/live-lab";
+import { createCourse, resetCourseCounter } from "../../../fixtures/course-factory";
+import { createLabWithSteps } from "../../../fixtures/lo-factory";
+
+function makeLiveLab(stepTitles: string[], autoNumber = false) {
+  resetCourseCounter();
+  const course = createCourse({ areLabStepsAutoNumbered: autoNumber }) as any;
+  const lab = createLabWithSteps(stepTitles) as any;
+  return new LiveLab(course, lab, "/lab/test-course/lab-01");
+}
+
+describe("LiveLab", () => {
+  describe("constructor and initialization", () => {
+    it("populates steps from lab los", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      expect(liveLab.steps).toHaveLength(2);
+    });
+
+    it("creates chaptersHtml map from los", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      expect(liveLab.chaptersHtml.size).toBe(2);
+    });
+
+    it("creates chaptersTitles map from los", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      expect(liveLab.chaptersTitles.size).toBe(2);
+    });
+
+    it("sets autoNumber from course property", () => {
+      const liveLab = makeLiveLab(["Intro"], true);
+      expect(liveLab.autoNumber).toBe(true);
+    });
+
+    it("sets url from labId parameter", () => {
+      const liveLab = makeLiveLab(["Intro"]);
+      expect(liveLab.url).toBe("/lab/test-course/lab-01");
+    });
+  });
+
+  describe("setFirstPageActive", () => {
+    it("sets current chapter to first step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.index).toBe(0);
+      expect(liveLab.content).toContain("Intro");
+    });
+  });
+
+  describe("setCurrentChapter", () => {
+    it("sets content for valid step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setCurrentChapter("Step01");
+      expect(liveLab.content).toContain("Intro");
+    });
+
+    it("does nothing for invalid step", () => {
+      const liveLab = makeLiveLab(["Intro"]);
+      liveLab.setCurrentChapter("NonExistent");
+      expect(liveLab.content).toBe("");
+    });
+
+    it("updates the index correctly", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise", "Summary"]);
+      liveLab.setCurrentChapter("Step02");
+      expect(liveLab.index).toBe(1);
+    });
+  });
+
+  describe("nextStep", () => {
+    it("returns next step when not at end", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise", "Summary"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.nextStep()).toBe("Step02");
+    });
+
+    it("returns empty string at last step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setCurrentChapter("Step02");
+      expect(liveLab.nextStep()).toBe("");
+    });
+  });
+
+  describe("prevStep", () => {
+    it("returns previous step when not at beginning", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setCurrentChapter("Step02");
+      expect(liveLab.prevStep()).toBe("Step01");
+    });
+
+    it("returns empty string at first step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.prevStep()).toBe("");
+    });
+  });
+
+  describe("navigation HTML", () => {
+    it("generates navbar HTML with step links", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.navbarHtml).toContain("Step01");
+      expect(liveLab.navbarHtml).toContain("Step02");
+    });
+
+    it("marks active step with bold class", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.navbarHtml).toContain("font-bold");
+    });
+
+    it("generates horizontal navbar with next link on first step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setFirstPageActive();
+      expect(liveLab.horizontalNavbarHtml).toContain("&rarr;");
+      expect(liveLab.horizontalNavbarHtml).not.toContain("&larr;");
+    });
+
+    it("generates horizontal navbar with both prev and next in middle", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise", "Summary"]);
+      liveLab.setCurrentChapter("Step02");
+      expect(liveLab.horizontalNavbarHtml).toContain("&larr;");
+      expect(liveLab.horizontalNavbarHtml).toContain("&rarr;");
+    });
+
+    it("generates horizontal navbar with only prev link on last step", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"]);
+      liveLab.setCurrentChapter("Step02");
+      expect(liveLab.horizontalNavbarHtml).toContain("&larr;");
+      expect(liveLab.horizontalNavbarHtml).not.toContain("&rarr;");
+    });
+
+    it("includes step numbers when autoNumber is true", () => {
+      const liveLab = makeLiveLab(["Intro", "Exercise"], true);
+      liveLab.setFirstPageActive();
+      expect(liveLab.navbarHtml).toContain("Step01:");
+    });
+  });
+});

--- a/tests/unit/services/schemas/schemas.test.ts
+++ b/tests/unit/services/schemas/schemas.test.ts
@@ -1,0 +1,217 @@
+import {
+  TutorsIdSchema,
+  CourseVisitSchema,
+  LoUserSchema,
+  LoRecordSchema,
+  TutorsConnectLatestRowSchema,
+  CatalogueEntrySchema,
+  IconTypeSchema,
+  ThemeSchema,
+  LayoutTypeSchema,
+  CardStyleTypeSchema,
+  CourseSentimentIdSchema,
+  CourseUrlResultSchema,
+  LoSchema,
+  LabStepSchema,
+  LabSchema,
+  CourseSchema
+} from "../../../contracts/schemas";
+import { assertValid, isValid, validationErrors } from "../../../contracts/validators";
+import { createTutorsId, createLoUser, resetUserCounter } from "../../../fixtures/user-factory";
+import { createCourse, resetCourseCounter } from "../../../fixtures/course-factory";
+import { createLoRecord, createLo } from "../../../fixtures/lo-factory";
+
+describe("Zod contract schemas", () => {
+  beforeEach(() => {
+    resetUserCounter();
+    resetCourseCounter();
+  });
+
+  describe("IconTypeSchema", () => {
+    it("validates a valid icon", () => {
+      expect(isValid(IconTypeSchema, { type: "fluent", color: "primary" })).toBe(true);
+    });
+
+    it("rejects missing fields", () => {
+      expect(isValid(IconTypeSchema, { type: "fluent" })).toBe(false);
+    });
+  });
+
+  describe("CourseSentimentIdSchema", () => {
+    it("accepts all valid sentiments", () => {
+      for (const s of ["neutral", "fine", "delighted", "confident", "overwhelmed", "confused", "drained"]) {
+        expect(isValid(CourseSentimentIdSchema, s)).toBe(true);
+      }
+    });
+
+    it("rejects invalid sentiment", () => {
+      expect(isValid(CourseSentimentIdSchema, "happy")).toBe(false);
+    });
+  });
+
+  describe("TutorsIdSchema", () => {
+    it("validates factory-created TutorsId", () => {
+      const user = createTutorsId();
+      expect(isValid(TutorsIdSchema, user)).toBe(true);
+    });
+
+    it("rejects missing login", () => {
+      const user = createTutorsId();
+      delete (user as any).login;
+      expect(isValid(TutorsIdSchema, user)).toBe(false);
+    });
+  });
+
+  describe("CourseVisitSchema", () => {
+    it("validates a course visit", () => {
+      const visit = {
+        id: "course-1",
+        title: "Test Course",
+        lastVisit: new Date(),
+        credits: "Author",
+        visits: 3
+      };
+      expect(isValid(CourseVisitSchema, visit)).toBe(true);
+    });
+
+    it("coerces string dates", () => {
+      const visit = {
+        id: "course-1",
+        title: "Test Course",
+        lastVisit: "2025-01-01",
+        credits: "Author"
+      };
+      const parsed = assertValid(CourseVisitSchema, visit);
+      expect(parsed.lastVisit).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("LoUserSchema", () => {
+    it("validates factory-created LoUser", () => {
+      const user = createLoUser();
+      expect(isValid(LoUserSchema, user)).toBe(true);
+    });
+  });
+
+  describe("LoRecordSchema", () => {
+    it("validates a factory-created LoRecord", () => {
+      const record = createLoRecord();
+      expect(isValid(LoRecordSchema, record)).toBe(true);
+    });
+  });
+
+  describe("TutorsConnectLatestRowSchema", () => {
+    it("validates a latest row", () => {
+      const row = {
+        course_id: "course-1",
+        student_id: "student-1",
+        payload: { key: "value" },
+        received_at: "2025-01-01T00:00:00Z"
+      };
+      expect(isValid(TutorsConnectLatestRowSchema, row)).toBe(true);
+    });
+  });
+
+  describe("CatalogueEntrySchema", () => {
+    it("validates a catalogue entry", () => {
+      const entry = {
+        course_id: "course-1",
+        visited_at: new Date(),
+        visit_count: 5,
+        course_record: {}
+      };
+      expect(isValid(CatalogueEntrySchema, entry)).toBe(true);
+    });
+  });
+
+  describe("LayoutTypeSchema", () => {
+    it("accepts expanded and compacted", () => {
+      expect(isValid(LayoutTypeSchema, "expanded")).toBe(true);
+      expect(isValid(LayoutTypeSchema, "compacted")).toBe(true);
+    });
+
+    it("rejects invalid layout", () => {
+      expect(isValid(LayoutTypeSchema, "grid")).toBe(false);
+    });
+  });
+
+  describe("CardStyleTypeSchema", () => {
+    it("accepts valid card styles", () => {
+      expect(isValid(CardStyleTypeSchema, "portrait")).toBe(true);
+      expect(isValid(CardStyleTypeSchema, "landscape")).toBe(true);
+      expect(isValid(CardStyleTypeSchema, "circular")).toBe(true);
+    });
+  });
+
+  describe("ThemeSchema", () => {
+    it("validates a theme with icons", () => {
+      const theme = {
+        name: "tutors",
+        icons: {
+          course: { type: "fluent", color: "primary" },
+          topic: { type: "fluent", color: "secondary" }
+        }
+      };
+      expect(isValid(ThemeSchema, theme)).toBe(true);
+    });
+  });
+
+  describe("LoSchema", () => {
+    it("validates a factory-created Lo", () => {
+      const lo = createLo();
+      expect(isValid(LoSchema, lo)).toBe(true);
+    });
+  });
+
+  describe("LabStepSchema", () => {
+    it("validates a lab step", () => {
+      const step = {
+        shortTitle: "Step01",
+        title: "# Introduction",
+        contentHtml: "<p>Content</p>",
+        type: "step"
+      };
+      expect(isValid(LabStepSchema, step)).toBe(true);
+    });
+  });
+
+  describe("CourseSchema", () => {
+    it("validates a minimal course structure", () => {
+      const course = {
+        courseId: "test-course",
+        courseUrl: "test-course.netlify.app",
+        title: "Test Course",
+        route: "/course/test-course",
+        type: "course" as const,
+        los: []
+      };
+      expect(isValid(CourseSchema, course)).toBe(true);
+    });
+  });
+
+  describe("CourseUrlResultSchema", () => {
+    it("validates a course URL result", () => {
+      expect(isValid(CourseUrlResultSchema, { courseId: "test", courseUrl: "test.netlify.app" })).toBe(true);
+    });
+  });
+
+  describe("validators", () => {
+    it("assertValid returns parsed data on success", () => {
+      const result = assertValid(TutorsIdSchema, createTutorsId());
+      expect(result.login).toBeDefined();
+    });
+
+    it("assertValid throws on invalid data", () => {
+      expect(() => assertValid(TutorsIdSchema, { name: "x" })).toThrow();
+    });
+
+    it("validationErrors returns empty array for valid data", () => {
+      expect(validationErrors(TutorsIdSchema, createTutorsId())).toHaveLength(0);
+    });
+
+    it("validationErrors returns errors for invalid data", () => {
+      const errors = validationErrors(TutorsIdSchema, { name: "x" });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/services/themes/themes-service.test.ts
+++ b/tests/unit/services/themes/themes-service.test.ts
@@ -1,0 +1,167 @@
+vi.mock("$lib/services/themes/events/festive.svelte", () => ({
+  makeItSnow: vi.fn(),
+  makeItStopSnowing: vi.fn()
+}));
+
+const { themeService } = await import("$lib/services/themes/services/themes.svelte");
+
+describe("themeService", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    themeService.isSnowing = false;
+    themeService.currentTheme.value = "tutors";
+    themeService.lightMode.value = "light";
+    themeService.layout.value = "expanded";
+    themeService.cardStyle.value = "portrait";
+    document.documentElement.classList.remove("dark");
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  describe("setDisplayMode", () => {
+    it("sets light mode", () => {
+      themeService.setDisplayMode("light");
+      expect(themeService.lightMode.value).toBe("light");
+      expect(localStorage.modeCurrent).toBe("light");
+    });
+
+    it("sets dark mode and adds class", () => {
+      themeService.setDisplayMode("dark");
+      expect(themeService.lightMode.value).toBe("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    it("removes dark class when switching to light", () => {
+      themeService.setDisplayMode("dark");
+      themeService.setDisplayMode("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("defaults to light when mode is falsy", () => {
+      themeService.setDisplayMode("");
+      expect(themeService.lightMode.value).toBe("light");
+    });
+
+    it("persists mode to localStorage", () => {
+      themeService.setDisplayMode("dark");
+      expect(localStorage.modeCurrent).toBe("dark");
+    });
+  });
+
+  describe("toggleDisplayMode", () => {
+    it("switches from light to dark", () => {
+      themeService.lightMode.value = "light";
+      themeService.toggleDisplayMode();
+      expect(themeService.lightMode.value).toBe("dark");
+    });
+
+    it("switches from dark to light", () => {
+      themeService.lightMode.value = "dark";
+      themeService.toggleDisplayMode();
+      expect(themeService.lightMode.value).toBe("light");
+    });
+  });
+
+  describe("setTheme", () => {
+    it("sets a valid theme", () => {
+      themeService.setTheme("classic");
+      expect(themeService.currentTheme.value).toBe("classic");
+    });
+
+    it("defaults to tutors when theme is empty", () => {
+      themeService.setTheme("");
+      expect(themeService.currentTheme.value).toBe("tutors");
+    });
+
+    it("persists theme to localStorage", () => {
+      themeService.setTheme("classic");
+      expect(localStorage.theme).toBe("classic");
+    });
+
+    it("sets data-theme attribute on documentElement", () => {
+      themeService.setTheme("rose");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("rose");
+    });
+  });
+
+  describe("setLayout", () => {
+    it("sets expanded layout", () => {
+      themeService.setLayout("expanded");
+      expect(themeService.layout.value).toBe("expanded");
+      expect(localStorage.layout).toBe("expanded");
+    });
+
+    it("sets compacted layout", () => {
+      themeService.setLayout("compacted");
+      expect(themeService.layout.value).toBe("compacted");
+    });
+
+    it("defaults to expanded when layout is falsy", () => {
+      themeService.setLayout("" as any);
+      expect(themeService.layout.value).toBe("expanded");
+    });
+  });
+
+  describe("toggleLayout", () => {
+    it("switches from expanded to compacted", () => {
+      themeService.layout.value = "expanded";
+      themeService.toggleLayout();
+      expect(themeService.layout.value).toBe("compacted");
+    });
+
+    it("switches from compacted to expanded", () => {
+      themeService.layout.value = "compacted";
+      themeService.toggleLayout();
+      expect(themeService.layout.value).toBe("expanded");
+    });
+  });
+
+  describe("setCardStyle", () => {
+    it("sets portrait style", () => {
+      themeService.setCardStyle("portrait");
+      expect(themeService.cardStyle.value).toBe("portrait");
+      expect(localStorage.cardStyle).toBe("portrait");
+    });
+
+    it("defaults to portrait when style is falsy", () => {
+      themeService.setCardStyle("" as any);
+      expect(themeService.cardStyle.value).toBe("portrait");
+    });
+  });
+
+  describe("getIcon", () => {
+    it("returns an icon from the current theme", () => {
+      themeService.currentTheme.value = "tutors";
+      const icon = themeService.getIcon("tutors");
+      expect(icon).toBeDefined();
+      expect(icon.type).toBeDefined();
+      expect(icon.color).toBeDefined();
+    });
+
+    it("returns default icon for unknown type", () => {
+      const icon = themeService.getIcon("nonexistent-type");
+      expect(icon).toBeDefined();
+    });
+  });
+
+  describe("eventTrigger", () => {
+    it("sets isSnowing to true for festive theme", () => {
+      themeService.currentTheme.value = "festive";
+      themeService.eventTrigger();
+      expect(themeService.isSnowing).toBe(true);
+    });
+
+    it("sets isSnowing to false when switching away from festive", () => {
+      themeService.isSnowing = true;
+      themeService.currentTheme.value = "tutors";
+      themeService.eventTrigger();
+      expect(themeService.isSnowing).toBe(false);
+    });
+
+    it("does not change isSnowing for non-festive theme when not snowing", () => {
+      themeService.isSnowing = false;
+      themeService.currentTheme.value = "tutors";
+      themeService.eventTrigger();
+      expect(themeService.isSnowing).toBe(false);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
   }
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
   // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,7 +58,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '$lib': path.resolve('./src/lib'),
-      '$app': path.resolve('./node_modules/@sveltejs/kit/src/runtime/app')
+      '$app': path.resolve('./node_modules/@sveltejs/kit/src/runtime/app'),
+      '$env/static/public': path.resolve('./tests/mocks/env-public.ts'),
+      '$env/static/private': path.resolve('./tests/mocks/env-private.ts'),
+      '$app/navigation': path.resolve('./tests/mocks/sveltekit-modules.ts'),
+      '$app/state': path.resolve('./tests/mocks/sveltekit-modules.ts')
     }
   }
 });


### PR DESCRIPTION
## Summary

- Add 6 unit test files covering services not yet tested: localStorageProfile, themes-service, live-lab, presence-service, supabase-client date utilities, and Zod schema validation (117 new tests)
- Add 4 E2E test specs (smoke, course-reader, lab-navigation, theme) with Playwright route interception helpers and mock course fixture
- Add Zod contract schemas and validators for all domain types (TutorsId, CourseVisit, LoRecord, Course, etc.)
- Add test fixture factories (course, lo, user) for consistent test data creation
- Extend vitest config with `$env/static/*` and `$app/navigation` aliases
- Upgrade localStorage mock to Proxy-based implementation supporting direct property access (e.g. `localStorage.courseVisits = ...`)
- Add document element spies for theme-related DOM mutation testing
- Add smoke project and env vars to Playwright config
- Add `zod` dependency and `test:smoke` npm script

All 257 tests pass (117 new + 140 existing).

## Test plan

- [ ] `npx vitest run` — all unit tests pass (14 test files, 257 tests)
- [ ] `npx vitest run --coverage` — coverage report shows new service areas
- [ ] `npx playwright test --project smoke` — smoke tests pass against dev server
- [ ] Verify no existing tests broken by setup.ts localStorage mock change

🤖 Generated with [Claude Code](https://claude.com/claude-code)