### PR TITLE
Fix Marp detection for production course JSON

### DIFF
--- a/src/lib/services/markdown/services/marp-renderer.ts
+++ b/src/lib/services/markdown/services/marp-renderer.ts
@@ -1,13 +1,26 @@
 import type { Lo } from "@tutors/tutors-model-lib";
 
 export function isMarpContent(lo: Lo): boolean {
-  if (lo.frontMatter?.marp === "true") {
+  const marpValue = lo.frontMatter?.marp;
+  if (marpValue === true || marpValue === "true") {
     return true;
   }
   if (lo.contentMd && /^---\s*\nmarp:\s*true/m.test(lo.contentMd)) {
     return true;
   }
   return false;
+}
+
+export function buildMarpMarkdown(lo: Lo): string {
+  if (lo.contentMd.trimStart().startsWith("---")) {
+    return lo.contentMd;
+  }
+  const fm = lo.frontMatter ?? {};
+  const lines = ["---", "marp: true"];
+  if (fm.theme) lines.push(`theme: ${fm.theme}`);
+  if (fm.paginate) lines.push(`paginate: ${fm.paginate}`);
+  lines.push("---", "");
+  return lines.join("\n") + lo.contentMd;
 }
 
 export async function renderMarpSlides(markdown: string): Promise<{ html: string; css: string }> {

--- a/src/lib/ui/learning-objects/content/TalkMarp.svelte
+++ b/src/lib/ui/learning-objects/content/TalkMarp.svelte
@@ -3,7 +3,7 @@
   import { onDestroy, onMount } from "svelte";
   import { Progress } from "@skeletonlabs/skeleton-svelte";
   import type { Talk } from "@tutors/tutors-model-lib";
-  import { renderMarpSlides } from "$lib/services/markdown/services/marp-renderer";
+  import { renderMarpSlides, buildMarpMarkdown } from "$lib/services/markdown/services/marp-renderer";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import Icon from "$lib/ui/components/Icon.svelte";
 
@@ -33,7 +33,7 @@
 
   async function loadSlides() {
     try {
-      const { html, css } = await renderMarpSlides(lo.contentMd);
+      const { html, css } = await renderMarpSlides(buildMarpMarkdown(lo));
       marpCss = css;
 
       const parser = new DOMParser();


### PR DESCRIPTION
## Summary
- Fixed `isMarpContent()` to accept both boolean `true` and string `"true"` for `frontMatter.marp` — the tutors generator outputs a boolean, causing detection to silently fail in production
- Added `buildMarpMarkdown()` to reconstruct Marp frontmatter directives (theme, paginate) when the generator strips them from `contentMd`

## Test plan
- [x] Verified locally against `reference-course` at `/talk/reference-course/topic-11-new-content-types/unit-1/talk-marp`
- [x] Slides render with navigation, theme, and pagination
- [x] No regressions on existing content types

🤖 Generated with [Claude Code](https://claude.com/claude-code)