### PR TITLE
Add interactive notebook cells with solution hiding and Pyodide execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,14 @@
       "name": "tutors",
       "version": "15.2.0",
       "dependencies": {
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.6",
         "@marp-team/marp-core": "^4.3.1",
         "@tutors/tutors-model-lib": "npm:@jsr/tutors__tutors-model-lib@^5.0.0",
         "@tutors/tutors-time-lib": "npm:@jsr/tutors__tutors-time-lib@^5.0.3",
+        "codemirror": "^6.0.2",
         "mermaid": "^11.16.0"
       },
       "devDependencies": {
@@ -201,6 +206,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -733,6 +739,112 @@
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/postcss-is-pseudo-class": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
@@ -786,35 +898,13 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1915,6 +2005,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2053,6 +2144,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
+    },
     "node_modules/@marp-team/marp-core": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-4.3.1.tgz",
@@ -2114,6 +2246,7 @@
       "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-3.2.2.tgz",
       "integrity": "sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "cssesc": "^3.0.0",
@@ -4118,6 +4251,7 @@
       "integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -4177,6 +4311,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -5001,6 +5136,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5028,6 +5164,7 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -5107,6 +5244,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -5214,6 +5352,7 @@
       "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5315,6 +5454,7 @@
       "integrity": "sha512-gIzazUkbQfv6T1rJHOLhMMKQnplKAvvQ7QNGaFwI6oCsp4z2aSDZCojGpX3QX3+MYsvJdyy/8BRIYVEbAkMkEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -5485,6 +5625,7 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -6142,6 +6283,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6386,6 +6528,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6705,6 +6848,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6774,6 +6932,12 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6826,6 +6990,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7247,6 +7412,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7608,6 +7774,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7672,6 +7839,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8421,6 +8589,7 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -9712,6 +9881,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -10684,6 +10854,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -10809,6 +10980,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10898,6 +11070,7 @@
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10929,6 +11102,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10945,6 +11119,7 @@
       "integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -11844,6 +12019,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
@@ -11869,6 +12050,7 @@
       "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12027,7 +12209,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -12296,6 +12479,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12540,6 +12724,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12736,6 +12921,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",
@@ -12877,6 +13063,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/weapon-regex": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,14 @@
     "vitest": "^3.2.7"
   },
   "dependencies": {
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.43.6",
     "@marp-team/marp-core": "^4.3.1",
     "@tutors/tutors-model-lib": "npm:@jsr/tutors__tutors-model-lib@^5.0.0",
     "@tutors/tutors-time-lib": "npm:@jsr/tutors__tutors-time-lib@^5.0.3",
+    "codemirror": "^6.0.2",
     "mermaid": "^11.16.0"
   }
 }

--- a/src/lib/ui/learning-objects/content/Notebook.svelte
+++ b/src/lib/ui/learning-objects/content/Notebook.svelte
@@ -4,6 +4,7 @@
   import { afterNavigate } from "$app/navigation";
   import { currentCodeTheme } from "$lib/services/markdown";
   import type { Lo } from "@tutors/tutors-model-lib";
+  import NotebookCodeEditor from "./NotebookCodeEditor.svelte";
 
   interface NotebookOutput {
     outputType: "stream" | "execute_result" | "display_data" | "error";
@@ -38,6 +39,21 @@
   let activeCellIndex = $state(0);
   let loaded = false;
   let revealedOutputs: Record<number, boolean> = $state({});
+  let revealedSolutions: Record<number, boolean> = $state({});
+
+  function isSolutionCell(cell: NotebookCell): boolean {
+    const tags = cell.metadata?.tags;
+    return Array.isArray(tags) && tags.includes("solution");
+  }
+
+  function isExerciseCell(cell: NotebookCell): boolean {
+    const tags = cell.metadata?.tags;
+    return Array.isArray(tags) && tags.includes("exercise");
+  }
+
+  function toggleSolution(index: number) {
+    revealedSolutions[index] = !revealedSolutions[index];
+  }
 
   const cells = $derived(lo.cells ?? []);
   const cellCount = $derived(cells.length);
@@ -138,7 +154,11 @@
                 >
                   <span class="flex items-center gap-2">
                     <span class="text-xs opacity-60 font-mono">
-                      {#if cell.cellType === "code"}
+                      {#if isSolutionCell(cell)}
+                        <span class="text-tertiary-500">&#128274;</span>
+                      {:else if isExerciseCell(cell)}
+                        <span class="text-primary-500">&#9998;</span>
+                      {:else if cell.cellType === "code"}
                         <span class="text-warning-500">&#9654;</span>
                       {:else if cell.cellType === "markdown"}
                         <span class="text-success-500">&#182;</span>
@@ -146,7 +166,7 @@
                         <span class="text-surface-500">&#9644;</span>
                       {/if}
                     </span>
-                    <span class="truncate">{getCellLabel(cell, i)}</span>
+                    <span class="truncate">{isSolutionCell(cell) ? "Solution" : getCellLabel(cell, i)}</span>
                   </span>
                 </button>
               </li>
@@ -172,7 +192,69 @@
               onclick={() => { activeCellIndex = i; }}
               onkeydown={() => {}}
             >
-              {#if cell.cellType === "code"}
+              {#if isSolutionCell(cell)}
+                <!-- Solution cell: two-stage reveal (code first, then output) -->
+                <div class="solution-cell">
+                  <button
+                    class="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium transition-colors
+                      {revealedSolutions[i]
+                        ? 'bg-tertiary-100 dark:bg-tertiary-900 text-tertiary-700 dark:text-tertiary-300'
+                        : 'bg-tertiary-50 dark:bg-tertiary-950 text-tertiary-600 dark:text-tertiary-400 hover:bg-tertiary-100 dark:hover:bg-tertiary-900'}"
+                    onclick={(e) => { e.stopPropagation(); toggleSolution(i); }}
+                  >
+                    <span class="text-base">{revealedSolutions[i] ? "▾" : "▸"}</span>
+                    <span>{revealedSolutions[i] ? "Hide Solution" : "Show Solution"}</span>
+                  </button>
+                  {#if revealedSolutions[i]}
+                    <div class="flex">
+                      <div class="flex-shrink-0 w-14 pt-3 text-right pr-2 font-mono text-xs text-surface-400 select-none">
+                        [{cell.executionCount ?? " "}]:
+                      </div>
+                      <div class="flex-1 min-w-0 overflow-x-auto">
+                        <div class="notebook-code-source">
+                          {@html cell.sourceHtml ?? ""}
+                        </div>
+                        {#if cell.outputsHtml}
+                          <div class="flex items-center border-t border-surface-200 dark:border-surface-700 px-3 py-1.5">
+                            <button
+                              class="run-button flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors
+                                {revealedOutputs[i]
+                                  ? 'bg-surface-200 dark:bg-surface-700 text-surface-600 dark:text-surface-300'
+                                  : 'bg-success-100 dark:bg-success-900 text-success-700 dark:text-success-300 hover:bg-success-200 dark:hover:bg-success-800'}"
+                              onclick={(e) => { e.stopPropagation(); toggleOutput(i); }}
+                            >
+                              <span class="text-sm">{revealedOutputs[i] ? "▾" : "▸"}</span>
+                              {revealedOutputs[i] ? "Hide Output" : "Run"}
+                            </button>
+                          </div>
+                          {#if revealedOutputs[i]}
+                            <div class="notebook-outputs border-t border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 p-3">
+                              {@html cell.outputsHtml}
+                            </div>
+                          {/if}
+                        {/if}
+                      </div>
+                    </div>
+                  {/if}
+                </div>
+
+              {:else if isExerciseCell(cell)}
+                <!-- Exercise cell (editable) -->
+                <div class="exercise-cell">
+                  <div class="flex items-center gap-2 px-4 py-1.5 bg-primary-50 dark:bg-primary-950 border-b border-surface-200 dark:border-surface-700">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-primary-600 dark:text-primary-400">Exercise</span>
+                  </div>
+                  <div class="flex">
+                    <div class="flex-shrink-0 w-14 pt-3 text-right pr-2 font-mono text-xs text-surface-400 select-none">
+                      [{cell.executionCount ?? " "}]:
+                    </div>
+                    <div class="flex-1 min-w-0 overflow-x-auto">
+                      <NotebookCodeEditor source={cell.source} language={lo.kernelLanguage ?? "python"} />
+                    </div>
+                  </div>
+                </div>
+
+              {:else if cell.cellType === "code"}
                 <!-- Code cell -->
                 <div class="flex">
                   <div class="flex-shrink-0 w-14 pt-3 text-right pr-2 font-mono text-xs text-surface-400 select-none">

--- a/src/lib/ui/learning-objects/content/NotebookCodeEditor.svelte
+++ b/src/lib/ui/learning-objects/content/NotebookCodeEditor.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { onMount, onDestroy } from "svelte";
+  import { currentCodeTheme } from "$lib/services/markdown";
+
+  interface Props {
+    source: string;
+    language?: string;
+  }
+  let { source, language = "python" }: Props = $props();
+
+  let editorContainer: HTMLDivElement;
+  let editorView: any = null;
+  let output = $state("");
+  let isRunning = $state(false);
+  let hasRun = $state(false);
+  let pyodideReady = $state(false);
+  let pyodideLoading = $state(false);
+  let pyodideInstance: any = null;
+
+  function getEditorContent(): string {
+    if (!editorView) return source;
+    return editorView.state.doc.toString();
+  }
+
+  async function loadPyodide() {
+    if (pyodideInstance) return pyodideInstance;
+    if ((window as any).__pyodideInstance) {
+      pyodideInstance = (window as any).__pyodideInstance;
+      pyodideReady = true;
+      return pyodideInstance;
+    }
+
+    pyodideLoading = true;
+    try {
+      if (!(window as any).loadPyodide) {
+        await new Promise<void>((resolve, reject) => {
+          const script = document.createElement("script");
+          script.src = "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js";
+          script.onload = () => resolve();
+          script.onerror = () => reject(new Error("Failed to load Pyodide"));
+          document.head.appendChild(script);
+        });
+      }
+      pyodideInstance = await (window as any).loadPyodide();
+      (window as any).__pyodideInstance = pyodideInstance;
+      pyodideReady = true;
+      return pyodideInstance;
+    } finally {
+      pyodideLoading = false;
+    }
+  }
+
+  async function runCode() {
+    isRunning = true;
+    output = "";
+    hasRun = true;
+
+    try {
+      const pyodide = await loadPyodide();
+      const code = getEditorContent();
+
+      pyodide.setStdout({ batched: (text: string) => { output += text + "\n"; } });
+      pyodide.setStderr({ batched: (text: string) => { output += text + "\n"; } });
+
+      const result = await pyodide.runPythonAsync(code);
+      if (result !== undefined && result !== null) {
+        const repr = result.toString();
+        if (repr && !output.endsWith(repr + "\n")) {
+          output += repr + "\n";
+        }
+      }
+    } catch (err: any) {
+      const msg = err?.message || String(err);
+      const cleaned = msg.replace(/PythonError: Traceback \(most recent call last\):\n\s+File "<exec>", line \d+, in <module>\n/, "");
+      output += cleaned;
+    } finally {
+      isRunning = false;
+    }
+  }
+
+  function resetCode() {
+    if (!editorView) return;
+    const { EditorView } = editorView.constructor as any;
+    editorView.dispatch({
+      changes: { from: 0, to: editorView.state.doc.length, insert: source }
+    });
+    output = "";
+    hasRun = false;
+  }
+
+  onMount(async () => {
+    if (!browser) return;
+
+    const { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } = await import("@codemirror/view");
+    const { EditorState } = await import("@codemirror/state");
+    const { python } = await import("@codemirror/lang-python");
+    const { oneDark } = await import("@codemirror/theme-one-dark");
+    const { defaultKeymap, history, historyKeymap } = await import("@codemirror/commands");
+    const { syntaxHighlighting, defaultHighlightStyle, bracketMatching } = await import("@codemirror/language");
+    const { closeBrackets, closeBracketsKeymap } = await import("@codemirror/autocomplete");
+
+    const isDark = currentCodeTheme.value?.includes("dark") ||
+                   currentCodeTheme.value?.includes("night") ||
+                   currentCodeTheme.value?.includes("dracula") ||
+                   document.documentElement.classList.contains("dark");
+
+    const extensions = [
+      lineNumbers(),
+      highlightActiveLine(),
+      highlightActiveLineGutter(),
+      history(),
+      bracketMatching(),
+      closeBrackets(),
+      keymap.of([...defaultKeymap, ...historyKeymap, ...closeBracketsKeymap]),
+      python(),
+      EditorView.lineWrapping,
+      EditorView.theme({
+        "&": { fontSize: "0.875rem" },
+        ".cm-content": { fontFamily: "monospace", padding: "0.75rem 0" },
+        ".cm-gutters": { minWidth: "3rem" },
+        ".cm-scroller": { overflow: "auto" }
+      })
+    ];
+
+    if (isDark) {
+      extensions.push(oneDark);
+    } else {
+      extensions.push(syntaxHighlighting(defaultHighlightStyle, { fallback: true }));
+    }
+
+    editorView = new EditorView({
+      state: EditorState.create({
+        doc: source,
+        extensions
+      }),
+      parent: editorContainer
+    });
+  });
+
+  onDestroy(() => {
+    editorView?.destroy();
+  });
+</script>
+
+<div class="notebook-editor" bind:this={editorContainer}></div>
+
+<div class="flex items-center gap-2 border-t border-surface-200 dark:border-surface-700 px-3 py-1.5">
+  <button
+    class="run-button flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors
+      bg-success-100 dark:bg-success-900 text-success-700 dark:text-success-300 hover:bg-success-200 dark:hover:bg-success-800
+      disabled:opacity-50 disabled:cursor-not-allowed"
+    onclick={runCode}
+    disabled={isRunning}
+  >
+    {#if isRunning}
+      <span class="text-sm animate-spin">&#9696;</span>
+      {pyodideLoading ? "Loading Python..." : "Running..."}
+    {:else}
+      <span class="text-sm">&#9654;</span>
+      Run
+    {/if}
+  </button>
+
+  {#if hasRun}
+    <button
+      class="flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors
+        bg-surface-100 dark:bg-surface-800 text-surface-500 dark:text-surface-400 hover:bg-surface-200 dark:hover:bg-surface-700"
+      onclick={resetCode}
+    >
+      Reset
+    </button>
+  {/if}
+</div>
+
+{#if hasRun && output}
+  <div class="notebook-outputs border-t border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 p-3">
+    <pre class="text-sm font-mono whitespace-pre-wrap">{output}</pre>
+  </div>
+{/if}
+
+<style>
+  .notebook-editor {
+    min-height: 4rem;
+  }
+  .notebook-editor :global(.cm-editor) {
+    border: none;
+    outline: none;
+  }
+  .notebook-editor :global(.cm-focused) {
+    outline: none;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Notebook cells with `metadata.tags: ["solution"]` are collapsed behind a **Show Solution** toggle with a two-stage reveal (code first, then Run to see output)
- Notebook cells with `metadata.tags: ["exercise"]` render as **editable CodeMirror editors** with a Run button that executes Python via **Pyodide** (WebAssembly) directly in the browser
- Pyodide loads from CDN on first Run click and is shared across all exercise cells on the page
- A Reset button restores the original skeleton code

## Changes
- `Notebook.svelte` — added solution/exercise cell detection via `metadata.tags`, collapsible solution UI, exercise cell routing to CodeMirror editor
- `NotebookCodeEditor.svelte` — new component wrapping CodeMirror 6 with Python syntax highlighting and Pyodide-powered code execution
- `package.json` — added CodeMirror 6 dependencies

## Test plan
- [ ] Open a notebook with exercise/solution cells
- [ ] Verify solution cells are hidden by default with "Show Solution" button
- [ ] Click Show Solution → code appears with "Run" button
- [ ] Click Run → output appears
- [ ] Verify exercise cells show editable CodeMirror editor
- [ ] Type Python code and click Run → output appears via Pyodide
- [ ] Click Reset → original skeleton code restored
- [ ] Verify regular code cells are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)