### PR TITLE
feat: add live class dashboard with engagement tracking and at-risk alerts

### DIFF
--- a/src/lib/services/community/index.ts
+++ b/src/lib/services/community/index.ts
@@ -8,8 +8,13 @@ export { catalogueService } from "./services/catalogue";
 export { liveService } from "./services/live.svelte";
 export { presenceService } from "./services/presence.svelte";
 export { analyticsService } from "./services/analytics.svelte";
+export { activityMonitorService } from "./services/activity-monitor.svelte";
+export { navTrackerService } from "./services/nav-tracker.svelte";
+export { dashboardAggregatorService } from "./services/dashboard-aggregator.svelte";
+export { startMockSimulation, stopMockSimulation } from "./services/dashboard-mock";
 
 // Type exports
-export type { LoUser, LoEvent, CatalogueService, CatalogueEntry } from "./types.svelte";
+export type { LoUser, LoEvent, CatalogueService, CatalogueEntry, EngagementState } from "./types.svelte";
+export type { DashboardAlert, StudentDashboardState, ClassHealthMetrics, AlertSeverity, NavEventRow } from "./types.svelte";
 export { LoRecord } from "./types.svelte";
 export { supabase } from "./utils/supabase-client";

--- a/src/lib/services/community/services/activity-monitor.svelte.ts
+++ b/src/lib/services/community/services/activity-monitor.svelte.ts
@@ -1,0 +1,137 @@
+import { browser } from "$app/environment";
+import { rune } from "$lib/runes.svelte";
+import type { EngagementState } from "../types.svelte";
+
+const IDLE_THRESHOLD_MS = 5 * 60 * 1000;
+const AWAY_THRESHOLD_MS = 15 * 60 * 1000;
+const TAB_HIDDEN_AWAY_MS = 2 * 60 * 1000;
+const THROTTLE_MS = 3000;
+const EVAL_INTERVAL_MS = 10_000;
+
+function throttle(fn: () => void, ms: number): () => void {
+  let last = 0;
+  return () => {
+    const now = Date.now();
+    if (now - last >= ms) {
+      last = now;
+      fn();
+    }
+  };
+}
+
+export const activityMonitorService = {
+  engagementState: rune<EngagementState>("active"),
+  lastActivityTs: 0,
+  tabHiddenSinceTs: 0,
+  isTabVisible: true,
+  evalIntervalId: null as ReturnType<typeof setInterval> | null,
+  throttledRecordActivity: null as (() => void) | null,
+  boundOnVisibilityChange: null as (() => void) | null,
+  boundOnFocus: null as (() => void) | null,
+  boundOnBlur: null as (() => void) | null,
+
+  start() {
+    if (!browser) return;
+
+    this.lastActivityTs = Date.now();
+    this.tabHiddenSinceTs = 0;
+    this.isTabVisible = !document.hidden;
+    this.engagementState.value = "active";
+
+    this.throttledRecordActivity = throttle(() => {
+      this.lastActivityTs = Date.now();
+      if (this.engagementState.value !== "active") {
+        this.engagementState.value = "active";
+      }
+    }, THROTTLE_MS);
+
+    const activityEvents = ["mousemove", "scroll", "keydown", "click", "touchstart"];
+    for (const event of activityEvents) {
+      document.addEventListener(event, this.throttledRecordActivity, { passive: true });
+    }
+
+    this.boundOnVisibilityChange = () => this.onVisibilityChange();
+    this.boundOnFocus = () => this.onWindowFocus();
+    this.boundOnBlur = () => this.onWindowBlur();
+
+    document.addEventListener("visibilitychange", this.boundOnVisibilityChange);
+    window.addEventListener("focus", this.boundOnFocus);
+    window.addEventListener("blur", this.boundOnBlur);
+
+    this.evalIntervalId = setInterval(() => this.evaluateState(), EVAL_INTERVAL_MS);
+  },
+
+  stop() {
+    if (!browser) return;
+
+    if (this.throttledRecordActivity) {
+      const activityEvents = ["mousemove", "scroll", "keydown", "click", "touchstart"];
+      for (const event of activityEvents) {
+        document.removeEventListener(event, this.throttledRecordActivity);
+      }
+    }
+    if (this.boundOnVisibilityChange) {
+      document.removeEventListener("visibilitychange", this.boundOnVisibilityChange);
+    }
+    if (this.boundOnFocus) {
+      window.removeEventListener("focus", this.boundOnFocus);
+    }
+    if (this.boundOnBlur) {
+      window.removeEventListener("blur", this.boundOnBlur);
+    }
+    if (this.evalIntervalId) {
+      clearInterval(this.evalIntervalId);
+      this.evalIntervalId = null;
+    }
+  },
+
+  onVisibilityChange() {
+    if (document.hidden) {
+      this.isTabVisible = false;
+      this.tabHiddenSinceTs = Date.now();
+    } else {
+      this.isTabVisible = true;
+      this.tabHiddenSinceTs = 0;
+      this.lastActivityTs = Date.now();
+    }
+    this.evaluateState();
+  },
+
+  onWindowFocus() {
+    this.isTabVisible = true;
+    this.tabHiddenSinceTs = 0;
+    this.lastActivityTs = Date.now();
+    this.evaluateState();
+  },
+
+  onWindowBlur() {
+    if (!this.tabHiddenSinceTs) {
+      this.tabHiddenSinceTs = Date.now();
+    }
+  },
+
+  evaluateState() {
+    const now = Date.now();
+    const elapsed = now - this.lastActivityTs;
+    const tabHiddenDuration = this.isTabVisible ? 0 : now - (this.tabHiddenSinceTs || now);
+
+    let state: EngagementState;
+    if (tabHiddenDuration >= TAB_HIDDEN_AWAY_MS) {
+      state = "away";
+    } else if (elapsed >= AWAY_THRESHOLD_MS) {
+      state = "away";
+    } else if (elapsed >= IDLE_THRESHOLD_MS) {
+      state = "idle";
+    } else {
+      state = "active";
+    }
+
+    if (this.engagementState.value !== state) {
+      this.engagementState.value = state;
+    }
+  },
+
+  getState(): EngagementState {
+    return this.engagementState.value;
+  }
+};

--- a/src/lib/services/community/services/dashboard-aggregator.svelte.ts
+++ b/src/lib/services/community/services/dashboard-aggregator.svelte.ts
@@ -1,0 +1,349 @@
+import PartySocket from "partysocket";
+import { PUBLIC_party_kit_main_room } from "$env/static/public";
+import { rune } from "$lib/runes.svelte";
+import {
+  LoRecord,
+  type ClassHealthMetrics,
+  type DashboardAlert,
+  type EngagementState,
+  type StudentDashboardState
+} from "../types.svelte";
+import { refreshLoRecord } from "./presence.svelte";
+
+const partyKitServer = PUBLIC_party_kit_main_room;
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+const STUCK_MULTIPLIER = 2;
+const THRASH_WINDOW_MS = 5 * 60 * 1000;
+const THRASH_MIN_COUNT = 3;
+const MAX_NAV_HISTORY = 20;
+const MAX_ACTIVE_ALERTS = 5;
+const ALERT_COOLDOWN_MS = 2 * 60 * 1000;
+const EVAL_INTERVAL_MS = 30_000;
+const IDLE_ALERT_MS = 5 * 60 * 1000;
+
+function getMedian(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function getMAD(values: number[], median: number): number {
+  if (values.length === 0) return 0;
+  const deviations = values.map((v) => Math.abs(v - median));
+  return getMedian(deviations);
+}
+
+function modifiedZScore(values: number[], x: number): number {
+  const median = getMedian(values);
+  const mad = getMAD(values, median);
+  if (mad === 0) return 0;
+  return (0.6745 * (x - median)) / mad;
+}
+
+function generateAlertId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export const dashboardAggregatorService = {
+  studentStates: rune<Map<string, StudentDashboardState>>(new Map()),
+  studentsOnline: rune<LoRecord[]>([]),
+  alerts: rune<DashboardAlert[]>([]),
+  classHealth: rune<ClassHealthMetrics>({
+    totalStudents: 0,
+    activeCount: 0,
+    idleCount: 0,
+    awayCount: 0,
+    disconnectedCount: 0,
+    activePercent: 100,
+    healthLevel: "green"
+  }),
+  isListening: rune<boolean>(false),
+
+  partyKitCourse: <PartySocket>{},
+  studentEventMap: new Map<string, LoRecord>(),
+  evalIntervalId: null as ReturnType<typeof setInterval> | null,
+  alertCooldowns: new Map<string, number>(),
+
+  startListening(courseId: string) {
+    this.stopListening();
+
+    if (PUBLIC_party_kit_main_room === "XXX") return;
+
+    this.partyKitCourse = new PartySocket({
+      host: partyKitServer,
+      room: courseId
+    });
+    this.partyKitCourse.addEventListener("message", this.onMessage.bind(this));
+    this.isListening.value = true;
+
+    this.evalIntervalId = setInterval(() => {
+      this.updateTimers();
+      this.evaluateAlerts();
+      this.computeClassHealth();
+    }, EVAL_INTERVAL_MS);
+  },
+
+  startMockListening() {
+    this.stopListening();
+    this.isListening.value = true;
+    this.evalIntervalId = setInterval(() => {
+      this.updateTimers();
+      this.evaluateAlerts();
+      this.computeClassHealth();
+    }, EVAL_INTERVAL_MS);
+  },
+
+  injectMessage(data: any) {
+    this.onMessage({ data: JSON.stringify(data) } as MessageEvent);
+  },
+
+  stopListening() {
+    if (this.partyKitCourse?.close) {
+      this.partyKitCourse.close();
+    }
+    if (this.evalIntervalId) {
+      clearInterval(this.evalIntervalId);
+      this.evalIntervalId = null;
+    }
+    this.studentStates.value = new Map();
+    this.studentsOnline.value = [];
+    this.studentEventMap.clear();
+    this.alerts.value = [];
+    this.alertCooldowns.clear();
+    this.isListening.value = false;
+  },
+
+  onMessage(event: MessageEvent) {
+    let data;
+    try {
+      data = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+
+    if (!data.user?.id || data.user.fullName === "Anon") return;
+
+    const existingLo = this.studentEventMap.get(data.user.id);
+    if (!existingLo) {
+      const lo = new LoRecord(data);
+      this.studentsOnline.value = [...this.studentsOnline.value, lo];
+      this.studentEventMap.set(data.user.id, lo);
+    } else {
+      refreshLoRecord(existingLo, data);
+      existingLo.engagement = data.engagement;
+      existingLo.heartbeatTs = data.heartbeatTs;
+    }
+
+    this.updateStudentState(data);
+    this.evaluateAlerts();
+    this.computeClassHealth();
+  },
+
+  updateStudentState(record: any) {
+    const userId = record.user?.id;
+    if (!userId) return;
+
+    const now = Date.now();
+    const states = new Map(this.studentStates.value);
+    const existing = states.get(userId);
+
+    const loChanged = existing ? existing.currentLoId !== record.loRoute : true;
+
+    const state: StudentDashboardState = {
+      userId,
+      fullName: record.user.fullName ?? userId,
+      avatar: record.user.avatar ?? "",
+      currentLoId: record.loRoute ?? "",
+      currentLoTitle: record.title ?? "",
+      currentLoType: record.type ?? "",
+      engagement: record.engagement ?? record.user.engagement ?? "active",
+      timeOnCurrentLoMs: loChanged ? 0 : (existing?.timeOnCurrentLoMs ?? 0),
+      currentLoStartTs: loChanged ? now : (existing?.currentLoStartTs ?? now),
+      lastEventTs: now,
+      navHistory: existing?.navHistory ?? [],
+      thrashCount: existing?.thrashCount ?? 0,
+      sentiment: record.user.sentiment ?? "neutral"
+    };
+
+    if (loChanged && record.loRoute) {
+      state.navHistory = [
+        ...state.navHistory.slice(-(MAX_NAV_HISTORY - 1)),
+        { loId: record.loRoute, ts: now, engagement: state.engagement }
+      ];
+      state.thrashCount = this.countThrashing(state.navHistory);
+    }
+
+    states.set(userId, state);
+    this.studentStates.value = states;
+  },
+
+  updateTimers() {
+    const now = Date.now();
+    const states = new Map(this.studentStates.value);
+    let changed = false;
+
+    for (const [, state] of states) {
+      const newTime = now - state.currentLoStartTs;
+      if (newTime !== state.timeOnCurrentLoMs) {
+        state.timeOnCurrentLoMs = newTime;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this.studentStates.value = states;
+    }
+  },
+
+  countThrashing(history: Array<{ loId: string; ts: number }>): number {
+    if (history.length < 3) return 0;
+    const now = Date.now();
+    const recent = history.filter((h) => now - h.ts < THRASH_WINDOW_MS);
+    let count = 0;
+    for (let i = 2; i < recent.length; i++) {
+      if (recent[i].loId === recent[i - 2].loId && recent[i].loId !== recent[i - 1].loId) {
+        count++;
+      }
+    }
+    return count;
+  },
+
+  evaluateAlerts() {
+    const states = this.studentStates.value;
+    const now = Date.now();
+    const newAlerts: DashboardAlert[] = [];
+
+    const timesOnLo = Array.from(states.values())
+      .filter((s) => now - s.lastEventTs < STALE_THRESHOLD_MS)
+      .map((s) => s.timeOnCurrentLoMs);
+    const medianTime = getMedian(timesOnLo);
+
+    const loStuckCounts = new Map<string, number>();
+
+    for (const [, state] of states) {
+      if (now - state.lastEventTs > STALE_THRESHOLD_MS) continue;
+
+      const isIdle = state.engagement === "idle" || state.engagement === "away";
+      const idleDuration = isIdle ? now - state.lastEventTs : 0;
+      const isOverMedian = medianTime > 0 && state.timeOnCurrentLoMs > medianTime * STUCK_MULTIPLIER;
+      const isThrashing = state.thrashCount >= THRASH_MIN_COUNT;
+      const zScore = timesOnLo.length >= 3 ? modifiedZScore(timesOnLo, state.timeOnCurrentLoMs) : 0;
+      const isOutlier = zScore > 3.5;
+
+      if (isIdle && idleDuration > IDLE_ALERT_MS && isOverMedian) {
+        this.addAlert(newAlerts, state, "red", "stuck-idle", `${state.fullName} may be stuck and idle on "${state.currentLoTitle}"`);
+        loStuckCounts.set(state.currentLoId, (loStuckCounts.get(state.currentLoId) ?? 0) + 1);
+      } else if (isThrashing) {
+        this.addAlert(newAlerts, state, "amber", "thrashing", `${state.fullName} is navigating back and forth`);
+      } else if (isOverMedian && (isIdle || isOutlier)) {
+        this.addAlert(newAlerts, state, "amber", "stuck", `${state.fullName} may be stuck on "${state.currentLoTitle}"`);
+        loStuckCounts.set(state.currentLoId, (loStuckCounts.get(state.currentLoId) ?? 0) + 1);
+      } else if (isIdle && idleDuration > IDLE_ALERT_MS) {
+        this.addAlert(newAlerts, state, "amber", "idle", `${state.fullName} has been idle for ${Math.round(idleDuration / 60000)} min`);
+      }
+    }
+
+    for (const [loId, count] of loStuckCounts) {
+      if (count >= 3) {
+        const loTitle = Array.from(states.values()).find((s) => s.currentLoId === loId)?.currentLoTitle ?? loId;
+        newAlerts.unshift({
+          id: generateAlertId(),
+          studentId: "",
+          studentName: "",
+          studentAvatar: "",
+          severity: "red",
+          rule: "cohort-stuck",
+          message: `${count} students may be stuck on "${loTitle}"`,
+          timestamp: now,
+          loId,
+          loTitle,
+          dismissed: false
+        });
+      }
+    }
+
+    const existing = this.alerts.value.filter((a) => !a.dismissed);
+    const combined = [...newAlerts, ...existing.filter((e) => !newAlerts.some((n) => n.studentId === e.studentId && n.rule === e.rule))];
+
+    const severityOrder: Record<string, number> = { red: 0, amber: 1, green: 2 };
+    combined.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+    this.alerts.value = combined.slice(0, MAX_ACTIVE_ALERTS * 2);
+  },
+
+  addAlert(
+    alerts: DashboardAlert[],
+    state: StudentDashboardState,
+    severity: "red" | "amber" | "green",
+    rule: string,
+    message: string
+  ) {
+    const key = `${state.userId}:${rule}`;
+    const now = Date.now();
+    const lastAlert = this.alertCooldowns.get(key);
+    if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) return;
+
+    this.alertCooldowns.set(key, now);
+    alerts.push({
+      id: generateAlertId(),
+      studentId: state.userId,
+      studentName: state.fullName,
+      studentAvatar: state.avatar,
+      severity,
+      rule,
+      message,
+      timestamp: now,
+      loId: state.currentLoId,
+      loTitle: state.currentLoTitle,
+      dismissed: false
+    });
+  },
+
+  dismissAlert(alertId: string) {
+    this.alerts.value = this.alerts.value.map((a) => (a.id === alertId ? { ...a, dismissed: true } : a));
+  },
+
+  computeClassHealth() {
+    const now = Date.now();
+    const states = this.studentStates.value;
+    let active = 0;
+    let idle = 0;
+    let away = 0;
+    let disconnected = 0;
+
+    for (const [, state] of states) {
+      if (now - state.lastEventTs > STALE_THRESHOLD_MS) {
+        disconnected++;
+      } else if (state.engagement === "active") {
+        active++;
+      } else if (state.engagement === "idle") {
+        idle++;
+      } else {
+        away++;
+      }
+    }
+
+    const total = states.size;
+    const activePercent = total > 0 ? Math.round((active / total) * 100) : 100;
+    let healthLevel: "green" | "amber" | "red";
+    if (activePercent >= 80) {
+      healthLevel = "green";
+    } else if (activePercent >= 60) {
+      healthLevel = "amber";
+    } else {
+      healthLevel = "red";
+    }
+
+    this.classHealth.value = {
+      totalStudents: total,
+      activeCount: active,
+      idleCount: idle,
+      awayCount: away,
+      disconnectedCount: disconnected,
+      activePercent,
+      healthLevel
+    };
+  }
+};

--- a/src/lib/services/community/services/dashboard-mock.ts
+++ b/src/lib/services/community/services/dashboard-mock.ts
@@ -1,0 +1,143 @@
+import { faker } from "@faker-js/faker";
+import { dashboardAggregatorService } from "./dashboard-aggregator.svelte";
+
+const MOCK_LOS = [
+  { route: "/topic/topic-01-getting-started", title: "Getting Started with Python", type: "topic" },
+  { route: "/talk/talk-1-welcome-to-python", title: "Welcome to Python", type: "talk" },
+  { route: "/note/note-1-python-ecosystem", title: "The Python Ecosystem", type: "note" },
+  { route: "/topic/topic-02-variables", title: "Variables and Data Types", type: "topic" },
+  { route: "/lab/book-variables-practice", title: "Variables Practice Lab", type: "lab" },
+  { route: "/topic/topic-04-control-flow", title: "Control Flow", type: "topic" },
+  { route: "/lab/book-control-flow-lab", title: "Control Flow Lab", type: "lab" },
+  { route: "/topic/topic-05-loops", title: "Loops", type: "topic" },
+  { route: "/lab/book-loops-lab", title: "Loops Lab", type: "lab" },
+  { route: "/topic/topic-06-functions", title: "Functions", type: "topic" },
+  { route: "/lab/book-functions-lab", title: "Functions Lab", type: "lab" },
+  { route: "/topic/topic-07-data-structures", title: "Data Structures", type: "topic" },
+  { route: "/lab/book-data-structures-lab", title: "Data Structures Lab", type: "lab" },
+  { route: "/topic/topic-10-oop", title: "Object-Oriented Programming", type: "topic" },
+  { route: "/lab/book-oop-lab", title: "OOP Lab", type: "lab" }
+];
+
+type Behavior = "active" | "idle" | "away" | "thrasher" | "stuck";
+
+interface MockStudent {
+  id: string;
+  fullName: string;
+  avatar: string;
+  behavior: Behavior;
+  currentLoIndex: number;
+  tickCount: number;
+  thrashToggle: boolean;
+}
+
+const BEHAVIORS: Behavior[] = [
+  "active", "active", "active", "active", "active",
+  "idle", "idle",
+  "away",
+  "thrasher",
+  "stuck"
+];
+
+let students: MockStudent[] = [];
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function createStudents(): MockStudent[] {
+  faker.seed(42);
+  return BEHAVIORS.map((behavior, i) => ({
+    id: faker.internet.username().toLowerCase().replace(/[^a-z0-9]/g, ""),
+    fullName: faker.person.fullName(),
+    avatar: `https://i.pravatar.cc/150?u=${i}`,
+    behavior,
+    currentLoIndex: i % MOCK_LOS.length,
+    tickCount: 0,
+    thrashToggle: false
+  }));
+}
+
+function buildPayload(student: MockStudent, courseId: string) {
+  const lo = MOCK_LOS[student.currentLoIndex];
+  let engagement: string;
+
+  switch (student.behavior) {
+    case "active":
+    case "thrasher":
+      engagement = "active";
+      break;
+    case "idle":
+    case "stuck":
+      engagement = student.tickCount < 5 ? "active" : "idle";
+      break;
+    case "away":
+      engagement = student.tickCount < 3 ? "active" : "away";
+      break;
+    default:
+      engagement = "active";
+  }
+
+  return {
+    courseId,
+    loRoute: lo.route,
+    title: lo.title,
+    type: lo.type,
+    img: "",
+    icon: null,
+    isPrivate: 0,
+    engagement,
+    heartbeatTs: Date.now(),
+    user: {
+      id: student.id,
+      fullName: student.fullName,
+      avatar: student.avatar,
+      sentiment: faker.helpers.arrayElement(["neutral", "positive", "negative"])
+    }
+  };
+}
+
+function tick(courseId: string) {
+  for (const student of students) {
+    student.tickCount++;
+
+    switch (student.behavior) {
+      case "active":
+        if (student.tickCount % faker.number.int({ min: 3, max: 6 }) === 0) {
+          student.currentLoIndex = (student.currentLoIndex + 1) % MOCK_LOS.length;
+        }
+        break;
+
+      case "thrasher":
+        if (student.tickCount % 2 === 0) {
+          student.thrashToggle = !student.thrashToggle;
+          student.currentLoIndex = student.thrashToggle ? 0 : 1;
+        }
+        break;
+
+      case "away":
+        if (student.tickCount % 8 !== 0) return;
+        break;
+    }
+
+    dashboardAggregatorService.injectMessage(buildPayload(student, courseId));
+  }
+}
+
+export function startMockSimulation(courseId: string) {
+  stopMockSimulation();
+  students = createStudents();
+  dashboardAggregatorService.startMockListening();
+
+  for (const student of students) {
+    dashboardAggregatorService.injectMessage(buildPayload(student, courseId));
+  }
+
+  intervalId = setInterval(() => tick(courseId), 3000);
+}
+
+export function stopMockSimulation() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+  students = [];
+  dashboardAggregatorService.stopListening();
+}

--- a/src/lib/services/community/services/nav-tracker.svelte.ts
+++ b/src/lib/services/community/services/nav-tracker.svelte.ts
@@ -1,0 +1,97 @@
+import { browser } from "$app/environment";
+import type { EngagementState } from "../types.svelte";
+import { insertNavEvent } from "../utils/supabase-client";
+
+const SESSION_GAP_MS = 20 * 60 * 1000;
+const SESSION_HARD_CUT_MS = 4 * 60 * 60 * 1000;
+const MAX_DURATION_MS = SESSION_GAP_MS;
+
+function loadSessionState(): { sessionId: string; sessionStartTs: number } | null {
+  if (!browser) return null;
+  try {
+    const raw = sessionStorage.getItem("tutors-nav-session");
+    if (raw) return JSON.parse(raw);
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function saveSessionState(sessionId: string, sessionStartTs: number): void {
+  if (!browser) return;
+  try {
+    sessionStorage.setItem("tutors-nav-session", JSON.stringify({ sessionId, sessionStartTs }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export const navTrackerService = {
+  sessionId: "",
+  sessionStartTs: 0,
+  lastNavTs: 0,
+  lastLoId: "",
+  lastNavEventTs: 0,
+
+  init() {
+    if (!browser) return;
+    const stored = loadSessionState();
+    if (stored) {
+      this.sessionId = stored.sessionId;
+      this.sessionStartTs = stored.sessionStartTs;
+    } else {
+      this.newSession();
+    }
+    this.lastNavTs = Date.now();
+    this.lastNavEventTs = Date.now();
+  },
+
+  newSession() {
+    this.sessionId = crypto.randomUUID();
+    this.sessionStartTs = Date.now();
+    this.lastLoId = "";
+    saveSessionState(this.sessionId, this.sessionStartTs);
+  },
+
+  logNavEvent(courseId: string, loId: string, loType: string, engagement: EngagementState, studentId: string) {
+    if (!browser || !courseId || !loId || !studentId) return;
+
+    const now = Date.now();
+
+    if (!this.sessionId) {
+      this.newSession();
+    }
+
+    const gap = now - this.lastNavTs;
+    const sessionAge = now - this.sessionStartTs;
+    if (gap > SESSION_GAP_MS || sessionAge > SESSION_HARD_CUT_MS) {
+      this.newSession();
+    }
+
+    let durationMs: number | null = null;
+    if (this.lastLoId && this.lastNavEventTs) {
+      durationMs = Math.min(now - this.lastNavEventTs, MAX_DURATION_MS);
+    }
+
+    const referrerLo = this.lastLoId || null;
+
+    void insertNavEvent({
+      student_id: studentId,
+      course_id: courseId,
+      lo_id: loId,
+      lo_type: loType,
+      session_id: this.sessionId,
+      duration_ms: durationMs,
+      referrer_lo: referrerLo,
+      engagement
+    });
+
+    this.lastLoId = loId;
+    this.lastNavTs = now;
+    this.lastNavEventTs = now;
+  },
+
+  getSessionId(): string {
+    return this.sessionId;
+  }
+};

--- a/src/lib/services/community/services/presence.svelte.ts
+++ b/src/lib/services/community/services/presence.svelte.ts
@@ -11,6 +11,7 @@ import { rune, tutorsId } from "$lib/runes.svelte";
 import { LoRecord, type LoUser, type PresenceService } from "../types.svelte";
 import type { TutorsId } from "$lib/services/connect";
 import { upsertTutorsConnectLatestLo } from "../utils/supabase-client";
+import { activityMonitorService } from "./activity-monitor.svelte";
 
 // Server URL from environment variables
 const partyKitServer = PUBLIC_party_kit_main_room;
@@ -87,6 +88,8 @@ export const presenceService: PresenceService = {
     if (lo.icon) {
       loRecord.icon = lo.icon;
     }
+    loRecord.engagement = activityMonitorService.getState();
+    loRecord.heartbeatTs = Date.now();
     const loRecordJson = JSON.stringify(loRecord);
     this.partyKitAll.send(loRecordJson);
     this.partyKitCourse.room = course.courseId;
@@ -108,6 +111,8 @@ export function refreshLoRecord(loEvent: LoRecord, nextLoEvent: LoRecord) {
   loEvent.title = nextLoEvent.title;
   loEvent.type = nextLoEvent.type;
   loEvent.user = nextLoEvent.user;
+  loEvent.engagement = nextLoEvent.engagement;
+  loEvent.heartbeatTs = nextLoEvent.heartbeatTs;
   if (nextLoEvent.icon) {
     loEvent.icon = nextLoEvent.icon;
     loEvent.img = undefined;
@@ -135,6 +140,7 @@ function getUser(tutorsId: TutorsId): LoUser {
     user.avatar = tutorsId.image;
     user.id = tutorsId.login;
     user.sentiment = tutorsId.sentiment ?? "neutral";
+    user.engagement = activityMonitorService.getState();
   }
   return user;
 }

--- a/src/lib/services/community/types.svelte.ts
+++ b/src/lib/services/community/types.svelte.ts
@@ -1,14 +1,15 @@
 import type { TutorsId } from "$lib/services/connect";
 import type { Course, IconType, Lo } from "@tutors/tutors-model-lib";
 import PartySocket from "partysocket";
-/**
- * Minimal user information for learning object interactions
- */
+
+export type EngagementState = "active" | "idle" | "away";
+
 export interface LoUser {
   fullName: string;
   avatar: string;
   id: string;
   sentiment: string;
+  engagement?: EngagementState;
 }
 
 /**
@@ -26,6 +27,8 @@ export class LoRecord {
   isPrivate: boolean = $state(false);
   user?: LoUser = $state<LoUser | undefined>();
   type: string = $state("");
+  engagement?: EngagementState = $state<EngagementState | undefined>();
+  heartbeatTs?: number = $state<number | undefined>();
 
   constructor(data: any) {
     Object.assign(this, data);
@@ -164,3 +167,58 @@ export interface CatalogueService {
   pruneCatalogue(fetchFunction: typeof fetch): Promise<void>;
   deleteCourses(courseIds: string[]): Promise<void>;
 }
+
+export type AlertSeverity = "red" | "amber" | "green";
+
+export interface DashboardAlert {
+  id: string;
+  studentId: string;
+  studentName: string;
+  studentAvatar: string;
+  severity: AlertSeverity;
+  rule: string;
+  message: string;
+  timestamp: number;
+  loId: string;
+  loTitle: string;
+  dismissed: boolean;
+}
+
+export interface StudentDashboardState {
+  userId: string;
+  fullName: string;
+  avatar: string;
+  currentLoId: string;
+  currentLoTitle: string;
+  currentLoType: string;
+  engagement: EngagementState;
+  timeOnCurrentLoMs: number;
+  currentLoStartTs: number;
+  lastEventTs: number;
+  navHistory: Array<{ loId: string; ts: number; engagement: EngagementState }>;
+  thrashCount: number;
+  sentiment: string;
+}
+
+export interface ClassHealthMetrics {
+  totalStudents: number;
+  activeCount: number;
+  idleCount: number;
+  awayCount: number;
+  disconnectedCount: number;
+  activePercent: number;
+  healthLevel: "green" | "amber" | "red";
+}
+
+export type NavEventRow = {
+  id: number;
+  student_id: string;
+  course_id: string;
+  lo_id: string;
+  lo_type: string;
+  session_id: string;
+  ts: string;
+  duration_ms: number | null;
+  referrer_lo: string | null;
+  engagement: string;
+};

--- a/src/lib/services/community/utils/supabase-client.ts
+++ b/src/lib/services/community/utils/supabase-client.ts
@@ -10,7 +10,7 @@ import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, PUBLIC_ANON_MODE } from 
 import type { Course, Lo } from "@tutors/tutors-model-lib";
 import type { TutorsId } from "$lib/services/connect";
 import { COURSE_SENTIMENT_IDS } from "$lib/services/connect/types";
-import type { TutorsConnectLatestRow } from "../types.svelte";
+import type { TutorsConnectLatestRow, NavEventRow } from "../types.svelte";
 import log from "$lib/services/logger";
 
 export let supabase: SupabaseClient;
@@ -454,4 +454,47 @@ export async function updateTutorsConnectUserOnlineStatus(githubId: string, onli
     log.error("updateTutorsConnectUserOnlineStatus failed:", error);
     throw error;
   }
+}
+
+export async function insertNavEvent(event: {
+  student_id: string;
+  course_id: string;
+  lo_id: string;
+  lo_type: string;
+  session_id: string;
+  duration_ms: number | null;
+  referrer_lo: string | null;
+  engagement: string;
+}): Promise<void> {
+  if (PUBLIC_ANON_MODE === "TRUE" || typeof supabase === "undefined") return;
+
+  const { error } = await supabase.from("nav_events").insert({
+    ...event,
+    ts: new Date().toISOString()
+  });
+
+  if (error) {
+    log.error("insertNavEvent failed:", error);
+  }
+}
+
+export async function getNavEventsByCourse(courseId: string, since: Date): Promise<NavEventRow[]> {
+  if (PUBLIC_ANON_MODE === "TRUE" || typeof supabase === "undefined") return [];
+
+  const id = courseId?.trim();
+  if (!id) return [];
+
+  const { data, error } = await supabase
+    .from("nav_events")
+    .select("*")
+    .eq("course_id", id)
+    .gte("ts", since.toISOString())
+    .order("ts", { ascending: false })
+    .limit(5000);
+
+  if (error) {
+    log.error("getNavEventsByCourse failed:", error);
+    return [];
+  }
+  return (data ?? []) as NavEventRow[];
 }

--- a/src/lib/services/connect/services/connect.svelte.ts
+++ b/src/lib/services/connect/services/connect.svelte.ts
@@ -10,7 +10,8 @@ import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import type { Course } from "@tutors/tutors-model-lib";
 
-import { analyticsService, presenceService } from "$lib/services/community";
+import { analyticsService, presenceService, activityMonitorService } from "$lib/services/community";
+import { navTrackerService } from "$lib/services/community/services/nav-tracker.svelte";
 import { PUBLIC_ANON_MODE } from "$env/static/public";
 
 import { currentCourse, currentLo, tutorsId } from "$lib/runes.svelte";
@@ -64,6 +65,7 @@ export const tutorsConnectService: TutorsConnectService = {
   async reconnect(user: TutorsId) {
     if (anonMode) return;
     presenceService.connectToAllCourseAccess();
+    navTrackerService.init();
     if (user) {
       this.profile = supabaseProfile;
       tutorsId.value = user;
@@ -187,6 +189,13 @@ export const tutorsConnectService: TutorsConnectService = {
       if (tutorsId.value.share === "true" && !currentCourse.value.isPrivate) {
         presenceService.sendLoEvent(currentCourse.value, currentLo.value, tutorsId.value);
       }
+      navTrackerService.logNavEvent(
+        currentCourse.value.courseId,
+        currentLo.value.route,
+        currentLo.value.type,
+        activityMonitorService.getState(),
+        tutorsId.value.login
+      );
     }
   },
 
@@ -196,17 +205,21 @@ export const tutorsConnectService: TutorsConnectService = {
    */
   startTimer() {
     if (anonMode) return;
+    activityMonitorService.start();
     this.intervalId = setInterval(() => {
-      if (!document.hidden && currentCourse.value && currentLo.value && tutorsId.value) {
-        if (analyticsEnabled) analyticsService.updatePageCount(currentCourse.value, currentLo.value, tutorsId.value);
+      if (currentCourse.value && currentLo.value && tutorsId.value) {
+        if (!document.hidden && analyticsEnabled) {
+          analyticsService.updatePageCount(currentCourse.value, currentLo.value, tutorsId.value);
+        }
+        if (tutorsId.value.share === "true" && !currentCourse.value.isPrivate) {
+          presenceService.sendLoEvent(currentCourse.value, currentLo.value, tutorsId.value);
+        }
       }
     }, 30 * 1000);
   },
 
-  /**
-   * Stops analytics update timer
-   */
   stopTimer() {
+    activityMonitorService.stop();
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -40,6 +40,20 @@ const en = {
   "menu.githubProfile": "Github Profile",
   "menu.disconnect": "Disconnect",
 
+  // Dashboard
+  "dashboard.title": "Class Dashboard",
+  "dashboard.classHealth": "Class Health",
+  "dashboard.alerts": "Alerts",
+  "dashboard.noAlerts": "No alerts — all students appear on track.",
+  "dashboard.progress": "Progress Distribution",
+  "dashboard.students": "Students",
+  "dashboard.active": "Active",
+  "dashboard.idle": "Idle",
+  "dashboard.away": "Away",
+  "dashboard.stuck": "may be stuck",
+  "dashboard.thrashing": "navigating back and forth",
+  "dashboard.timeOnLo": "on current content",
+
   // Home page
   "home.title": "Tutors:",
   "home.titleAn": "An",

--- a/src/lib/services/themes/icons/fluent-icons.ts
+++ b/src/lib/services/themes/icons/fluent-icons.ts
@@ -45,6 +45,10 @@ export const FluentIconLib: IconLib = {
   tutorsTime: { type: "fluent:clock-alarm-24-filled", color: "primary" },
   timeExport: { type: "fluent:save-arrow-right-24-filled", color: "success" },
   live: { type: "fluent:people-community-24-filled", color: "success" },
+  dashboard: { type: "fluent:data-bar-vertical-24-filled", color: "primary" },
+  engagementActive: { type: "fluent:presence-available-24-filled", color: "success" },
+  engagementIdle: { type: "fluent:presence-away-24-filled", color: "warning" },
+  engagementAway: { type: "fluent:presence-offline-24-filled", color: "error" },
 
   // app icons
   search: { type: "fluent:search-24-filled", color: "primary" },

--- a/src/lib/ui/dashboard/ActivitySparkline.svelte
+++ b/src/lib/ui/dashboard/ActivitySparkline.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  let {
+    events,
+    width = 120,
+    height = 24
+  } = $props<{
+    events: Array<{ ts: number }>;
+    width?: number;
+    height?: number;
+  }>();
+
+  const points = $derived.by(() => {
+    if (events.length < 2) return [];
+    const sorted = [...events].sort((a, b) => a.ts - b.ts);
+    const minTs = sorted[0].ts;
+    const maxTs = sorted[sorted.length - 1].ts;
+    const range = maxTs - minTs || 1;
+    const padding = 4;
+    const usableWidth = width - padding * 2;
+    const usableHeight = height - padding * 2;
+    return sorted.map((e, i) => ({
+      x: padding + (e.ts - minTs) / range * usableWidth,
+      y: padding + (i / (sorted.length - 1)) * usableHeight
+    }));
+  });
+
+  const polylinePoints = $derived(points.map((p) => `${p.x},${p.y}`).join(" "));
+</script>
+
+<svg {width} {height} class="inline-block" viewBox="0 0 {width} {height}">
+  {#if points.length >= 2}
+    <polyline
+      points={polylinePoints}
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      opacity="0.5"
+    />
+    {#each points as point}
+      <circle cx={point.x} cy={point.y} r="2" fill="currentColor" />
+    {/each}
+  {:else if events.length === 1}
+    <circle cx={width / 2} cy={height / 2} r="3" fill="currentColor" />
+  {:else}
+    <text x={width / 2} y={height / 2 + 4} text-anchor="middle" font-size="10" fill="currentColor" opacity="0.4">--</text>
+  {/if}
+</svg>

--- a/src/lib/ui/dashboard/AlertPanel.svelte
+++ b/src/lib/ui/dashboard/AlertPanel.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import Iconify from "@iconify/svelte";
+  import type { DashboardAlert } from "$lib/services/community/types.svelte";
+  import { dashboardAggregatorService } from "$lib/services/community";
+  import { t } from "$lib/services/i18n";
+
+  let { alerts } = $props<{ alerts: DashboardAlert[] }>();
+
+  const visibleAlerts = $derived(alerts.filter((a: DashboardAlert) => !a.dismissed));
+
+  function dismiss(id: string) {
+    dashboardAggregatorService.dismissAlert(id);
+  }
+
+  function formatTime(ts: number): string {
+    const diff = Math.round((Date.now() - ts) / 1000);
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return `${Math.floor(diff / 3600)}h ago`;
+  }
+
+  const severityConfig = {
+    red: { border: "border-l-error-500", icon: "fluent:warning-24-filled", iconColor: "var(--color-error-500)" },
+    amber: { border: "border-l-warning-500", icon: "fluent:info-24-filled", iconColor: "var(--color-warning-500)" },
+    green: { border: "border-l-success-500", icon: "fluent:checkmark-circle-24-filled", iconColor: "var(--color-success-500)" }
+  };
+</script>
+
+<div class="flex flex-col gap-2">
+  <h3 class="text-sm font-semibold">{t("dashboard.alerts")}</h3>
+
+  {#if visibleAlerts.length === 0}
+    <p class="text-surface-500 py-4 text-center text-sm">{t("dashboard.noAlerts")}</p>
+  {:else}
+    <div class="flex max-h-96 flex-col gap-2 overflow-y-auto">
+      {#each visibleAlerts as alert}
+        {@const config = severityConfig[alert.severity as keyof typeof severityConfig]}
+        <div class="bg-surface-100-800-token flex items-start gap-3 rounded-lg border-l-4 {config.border} p-3">
+          <Iconify icon={config.icon} color={config.iconColor} height="20" class="mt-0.5 shrink-0" />
+
+          {#if alert.studentAvatar}
+            <img src={alert.studentAvatar} alt="" class="h-8 w-8 shrink-0 rounded-full" />
+          {/if}
+
+          <div class="min-w-0 flex-1">
+            <p class="text-sm">{alert.message}</p>
+            <p class="text-surface-500 text-xs">{formatTime(alert.timestamp)}</p>
+          </div>
+
+          <button
+            onclick={() => dismiss(alert.id)}
+            class="text-surface-400 hover:text-surface-600 shrink-0 p-1"
+            aria-label="Dismiss alert"
+          >
+            <Iconify icon="carbon:close-outline" height="16" />
+          </button>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/lib/ui/dashboard/ClassHealthGauge.svelte
+++ b/src/lib/ui/dashboard/ClassHealthGauge.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { ClassHealthMetrics } from "$lib/services/community/types.svelte";
+  import { t } from "$lib/services/i18n";
+
+  let { health } = $props<{ health: ClassHealthMetrics }>();
+
+  const activeWidth = $derived(health.totalStudents > 0 ? (health.activeCount / health.totalStudents) * 100 : 100);
+  const idleWidth = $derived(health.totalStudents > 0 ? (health.idleCount / health.totalStudents) * 100 : 0);
+  const awayWidth = $derived(health.totalStudents > 0 ? ((health.awayCount + health.disconnectedCount) / health.totalStudents) * 100 : 0);
+
+  const borderColor = $derived(
+    health.healthLevel === "green" ? "border-success-500" : health.healthLevel === "amber" ? "border-warning-500" : "border-error-500"
+  );
+</script>
+
+<div class="bg-surface-100-800-token rounded-xl border {borderColor} p-4">
+  <h3 class="mb-2 text-sm font-semibold">{t("dashboard.classHealth")}</h3>
+
+  <div class="flex h-6 w-full overflow-hidden rounded-full">
+    {#if activeWidth > 0}
+      <div class="bg-success-500 flex items-center justify-center text-xs font-bold text-white transition-all" style="width: {activeWidth}%">
+        {#if activeWidth > 10}{health.activeCount}{/if}
+      </div>
+    {/if}
+    {#if idleWidth > 0}
+      <div class="bg-warning-500 flex items-center justify-center text-xs font-bold text-white transition-all" style="width: {idleWidth}%">
+        {#if idleWidth > 10}{health.idleCount}{/if}
+      </div>
+    {/if}
+    {#if awayWidth > 0}
+      <div class="bg-error-500 flex items-center justify-center text-xs font-bold text-white transition-all" style="width: {awayWidth}%">
+        {#if awayWidth > 10}{health.awayCount + health.disconnectedCount}{/if}
+      </div>
+    {/if}
+  </div>
+
+  <div class="mt-2 flex gap-4 text-xs">
+    <span class="flex items-center gap-1">
+      <span class="bg-success-500 inline-block h-2.5 w-2.5 rounded-full"></span>
+      {t("dashboard.active")} ({health.activeCount})
+    </span>
+    <span class="flex items-center gap-1">
+      <span class="bg-warning-500 inline-block h-2.5 w-2.5 rounded-full"></span>
+      {t("dashboard.idle")} ({health.idleCount})
+    </span>
+    <span class="flex items-center gap-1">
+      <span class="bg-error-500 inline-block h-2.5 w-2.5 rounded-full"></span>
+      {t("dashboard.away")} ({health.awayCount + health.disconnectedCount})
+    </span>
+    <span class="text-surface-500 ml-auto">
+      {health.totalStudents} total &middot; {health.activePercent}% active
+    </span>
+  </div>
+</div>

--- a/src/lib/ui/dashboard/ProgressFunnel.svelte
+++ b/src/lib/ui/dashboard/ProgressFunnel.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { StudentDashboardState } from "$lib/services/community/types.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
+  import { t } from "$lib/services/i18n";
+
+  let { students } = $props<{ students: Map<string, StudentDashboardState> }>();
+
+  const distribution = $derived.by(() => {
+    const counts = new Map<string, { count: number; type: string; title: string }>();
+    for (const [, state] of students) {
+      const key = state.currentLoId || "unknown";
+      const existing = counts.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        counts.set(key, {
+          count: 1,
+          type: state.currentLoType,
+          title: state.currentLoTitle || key
+        });
+      }
+    }
+    return [...counts.entries()]
+      .map(([id, data]) => ({ id, ...data }))
+      .sort((a, b) => b.count - a.count);
+  });
+
+  const maxCount = $derived(distribution.length > 0 ? distribution[0].count : 1);
+</script>
+
+<div class="flex flex-col gap-2">
+  <h3 class="text-sm font-semibold">{t("dashboard.progress")}</h3>
+
+  {#if distribution.length === 0}
+    <p class="text-surface-500 py-4 text-center text-sm">No students connected</p>
+  {:else}
+    <div class="flex flex-col gap-1.5">
+      {#each distribution as item}
+        {@const widthPct = Math.max((item.count / maxCount) * 100, 8)}
+        <div class="flex items-center gap-2">
+          <div class="w-6 shrink-0 text-center">
+            <Icon type={item.type} height="18" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="bg-surface-200-700-token h-6 w-full overflow-hidden rounded">
+              <div
+                class="preset-filled-primary-500 flex h-full items-center rounded px-2 text-xs font-medium text-white transition-all"
+                style="width: {widthPct}%"
+              >
+                {item.count}
+              </div>
+            </div>
+          </div>
+          <span class="text-surface-600 w-36 shrink-0 truncate text-xs" title={item.title}>
+            {item.title}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/lib/ui/dashboard/StudentStateGrid.svelte
+++ b/src/lib/ui/dashboard/StudentStateGrid.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { EngagementState, StudentDashboardState } from "$lib/services/community/types.svelte";
+  import ActivitySparkline from "./ActivitySparkline.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
+
+  let {
+    students,
+    filter = "all"
+  } = $props<{
+    students: Map<string, StudentDashboardState>;
+    filter?: EngagementState | "all";
+  }>();
+
+  const STALE_MS = 5 * 60 * 1000;
+
+  const filteredStudents = $derived.by((): StudentDashboardState[] => {
+    const now = Date.now();
+    const all = [...students.values()] as StudentDashboardState[];
+    const arr = all.filter((s) => now - s.lastEventTs < STALE_MS);
+    if (filter === "all") return arr;
+    return arr.filter((s) => s.engagement === filter);
+  });
+
+  function formatDuration(ms: number): string {
+    const totalSec = Math.floor(ms / 1000);
+    if (totalSec < 60) return `${totalSec}s`;
+    const min = Math.floor(totalSec / 60);
+    if (min < 60) return `${min}m`;
+    const hr = Math.floor(min / 60);
+    const rem = min % 60;
+    return rem > 0 ? `${hr}h ${rem}m` : `${hr}h`;
+  }
+
+  const engagementColors: Record<EngagementState, string> = {
+    active: "bg-success-500",
+    idle: "bg-warning-500",
+    away: "bg-error-500"
+  };
+</script>
+
+<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+  {#each filteredStudents as student (student.userId)}
+    {@const dotColor = engagementColors[student.engagement] ?? "bg-surface-500"}
+    <div class="bg-surface-100-800-token flex items-center gap-3 rounded-lg border border-surface-200 p-3 dark:border-surface-700">
+      <div class="relative shrink-0">
+        <img src={student.avatar} alt={student.fullName} class="h-10 w-10 rounded-full" />
+        <span class="absolute -right-0.5 -bottom-0.5 h-3 w-3 rounded-full border-2 border-white dark:border-surface-800 {dotColor}"></span>
+      </div>
+
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-1">
+          <span class="truncate text-sm font-medium">{student.fullName}</span>
+          <Icon type={student.sentiment} height="14" />
+        </div>
+        <div class="flex items-center gap-1.5">
+          <Icon type={student.currentLoType} height="14" />
+          <span class="text-surface-500 truncate text-xs" title={student.currentLoTitle}>
+            {student.currentLoTitle}
+          </span>
+        </div>
+      </div>
+
+      <div class="flex shrink-0 flex-col items-end gap-1">
+        <span class="text-surface-500 text-xs font-mono">
+          {formatDuration(student.timeOnCurrentLoMs)}
+        </span>
+        <ActivitySparkline events={student.navHistory} width={60} height={16} />
+      </div>
+    </div>
+  {/each}
+
+  {#if filteredStudents.length === 0}
+    <p class="text-surface-500 col-span-full py-8 text-center text-sm">No students match this filter</p>
+  {/if}
+</div>

--- a/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
+++ b/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
@@ -52,6 +52,7 @@
           <MenuItem link="https://time.tutors.dev/{currentCourse.value?.courseId}" text={t("menu.educatorTime")} type="tutorsTime" targetStr="_blank" />
         {/if}
         <MenuItem link="/live/{currentCourse.value?.courseId}" text={t("menu.tutorsLive")} type="live" targetStr="_blank" />
+        <MenuItem link="/live/{currentCourse.value?.courseId}/dashboard" text={t("dashboard.title")} type="dashboard" targetStr="_blank" />
 
         <li class="option hover:preset-tonal p-0!">
           <OnlineButton />

--- a/src/lib/ui/time/StudentCard.svelte
+++ b/src/lib/ui/time/StudentCard.svelte
@@ -47,8 +47,12 @@
 <div class={cardShellClass}>
   <div class="flex h-full w-full flex-col">
     <div class="relative flex w-full shrink-0 items-center justify-center border-surface-300 border-b px-3 py-3 dark:border-surface-600">
-      <span class="absolute top-1/2 left-3 z-10 -translate-y-1/2">
+      <span class="absolute top-1/2 left-3 z-10 -translate-y-1/2 flex items-center gap-1">
         <Icon type={sentiment} tip={`Sentiment — ${sentiment}.`} height="28" />
+        {#if lo.engagement}
+          {@const engColor = lo.engagement === "active" ? "bg-success-500" : lo.engagement === "idle" ? "bg-warning-500" : "bg-error-500"}
+          <span class="inline-block h-2.5 w-2.5 rounded-full {engColor}" title={lo.engagement}></span>
+        {/if}
       </span>
       {#if student.id}
         <a

--- a/src/routes/(course-reader)/+layout.svelte
+++ b/src/routes/(course-reader)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import CourseShell from "$lib/ui/TutorsShell.svelte";
-  import type { Snippet } from "svelte";
+  import { onDestroy, type Snippet } from "svelte";
   import { tutorsConnectService } from "$lib/services/connect";
   import { page } from "$app/state";
   import { currentCourse } from "$lib/runes.svelte";
@@ -10,6 +10,10 @@
   let { children }: Props = $props();
 
   tutorsConnectService.startTimer();
+
+  onDestroy(() => {
+    tutorsConnectService.stopTimer();
+  });
 
   let lastCourseId = "";
   $effect(() => {

--- a/src/routes/(live)/live/[courseid]/dashboard/+page.svelte
+++ b/src/routes/(live)/live/[courseid]/dashboard/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { page } from "$app/stores";
+  import { dashboardAggregatorService } from "$lib/services/community";
+  import { startMockSimulation, stopMockSimulation } from "$lib/services/community/services/dashboard-mock";
+  import ClassHealthGauge from "$lib/ui/dashboard/ClassHealthGauge.svelte";
+  import AlertPanel from "$lib/ui/dashboard/AlertPanel.svelte";
+  import ProgressFunnel from "$lib/ui/dashboard/ProgressFunnel.svelte";
+  import StudentStateGrid from "$lib/ui/dashboard/StudentStateGrid.svelte";
+  import CourseGroupHeader from "$lib/ui/time/CourseGroupHeader.svelte";
+  import { Tabs } from "@skeletonlabs/skeleton-svelte";
+  import { t } from "$lib/services/i18n";
+  import type { Course } from "@tutors/tutors-model-lib";
+  import type { EngagementState } from "$lib/services/community/types.svelte";
+
+  interface Props {
+    data: { courseid: string; course: Course };
+  }
+  let { data }: Props = $props();
+
+  let studentFilter = $state<EngagementState | "all">("all");
+  let isMock = false;
+
+  onMount(() => {
+    isMock = $page.url.searchParams.get("mock") === "true";
+    if (isMock) {
+      startMockSimulation(data.courseid);
+    } else {
+      dashboardAggregatorService.startListening(data.courseid);
+    }
+  });
+
+  onDestroy(() => {
+    if (isMock) {
+      stopMockSimulation();
+    } else {
+      dashboardAggregatorService.stopListening();
+    }
+  });
+
+  const health = $derived(dashboardAggregatorService.classHealth.value);
+  const alerts = $derived(dashboardAggregatorService.alerts.value);
+  const students = $derived(dashboardAggregatorService.studentStates.value);
+</script>
+
+<div class="relative flex w-full min-w-0 flex-col gap-4 p-4">
+  {#if isMock}
+    <span class="absolute top-2 right-4 z-50 rounded bg-warning-500 px-2 py-0.5 text-xs font-bold text-black">MOCK MODE</span>
+  {/if}
+  <section class="w-full">
+    <CourseGroupHeader courseId={data.course.courseId!} courseTitle={data.course.title!} />
+  </section>
+
+  <section class="w-full">
+    <ClassHealthGauge {health} />
+  </section>
+
+  <div class="grid w-full gap-4 lg:grid-cols-3">
+    <div class="lg:col-span-2">
+      <div class="bg-surface-100-800-token rounded-xl border border-surface-200 p-4 dark:border-surface-700">
+        <AlertPanel {alerts} />
+      </div>
+    </div>
+    <div>
+      <div class="bg-surface-100-800-token rounded-xl border border-surface-200 p-4 dark:border-surface-700">
+        <ProgressFunnel {students} />
+      </div>
+    </div>
+  </div>
+
+  <section class="bg-surface-100-800-token w-full rounded-xl border border-surface-200 p-4 dark:border-surface-700">
+    <h3 class="mb-3 text-sm font-semibold">{t("dashboard.students") ?? "Students"}</h3>
+    <Tabs defaultValue="all">
+      <Tabs.List>
+        <Tabs.Trigger value="all" onclick={() => (studentFilter = "all")}>
+          All ({students.size})
+        </Tabs.Trigger>
+        <Tabs.Trigger value="active" onclick={() => (studentFilter = "active")}>
+          {t("dashboard.active")} ({health.activeCount})
+        </Tabs.Trigger>
+        <Tabs.Trigger value="idle" onclick={() => (studentFilter = "idle")}>
+          {t("dashboard.idle")} ({health.idleCount})
+        </Tabs.Trigger>
+        <Tabs.Trigger value="away" onclick={() => (studentFilter = "away")}>
+          {t("dashboard.away")} ({health.awayCount})
+        </Tabs.Trigger>
+        <Tabs.Indicator />
+      </Tabs.List>
+      <Tabs.Content value="all">
+        <StudentStateGrid {students} filter="all" />
+      </Tabs.Content>
+      <Tabs.Content value="active">
+        <StudentStateGrid {students} filter="active" />
+      </Tabs.Content>
+      <Tabs.Content value="idle">
+        <StudentStateGrid {students} filter="idle" />
+      </Tabs.Content>
+      <Tabs.Content value="away">
+        <StudentStateGrid {students} filter="away" />
+      </Tabs.Content>
+    </Tabs>
+  </section>
+</div>

--- a/src/routes/(live)/live/[courseid]/dashboard/+page.ts
+++ b/src/routes/(live)/live/[courseid]/dashboard/+page.ts
@@ -1,0 +1,18 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+
+export const load = async ({ params, fetch, url }) => {
+  const isMock = url.searchParams.get("mock") === "true";
+  try {
+    const course = await courseService.readCourse(params.courseid, fetch);
+    currentCourse.value = course;
+    return { courseid: params.courseid, course };
+  } catch (e) {
+    if (isMock) {
+      const stub = { courseId: params.courseid, title: params.courseid } as any;
+      currentCourse.value = stub;
+      return { courseid: params.courseid, course: stub };
+    }
+    throw e;
+  }
+};

--- a/supabase/migrations/001_create_nav_events.sql
+++ b/supabase/migrations/001_create_nav_events.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS nav_events (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  student_id    TEXT NOT NULL,
+  course_id     TEXT NOT NULL,
+  lo_id         TEXT NOT NULL,
+  lo_type       TEXT NOT NULL DEFAULT '',
+  session_id    UUID NOT NULL,
+  ts            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  duration_ms   INTEGER,
+  referrer_lo   TEXT,
+  engagement    TEXT NOT NULL DEFAULT 'active'
+);
+
+CREATE INDEX IF NOT EXISTS idx_nav_events_course_ts
+  ON nav_events (course_id, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_nav_events_student_session
+  ON nav_events (student_id, session_id, ts);
+
+CREATE INDEX IF NOT EXISTS idx_nav_events_lo
+  ON nav_events (course_id, lo_id, ts DESC);
+
+ALTER TABLE nav_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Students insert own nav events"
+  ON nav_events FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can read nav events"
+  ON nav_events FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary

- **Engagement state detection**: Client-side activity monitor tracks active/idle/away states via input events and Page Visibility API, broadcast with every PartyKit heartbeat
- **Navigation tracking**: Logs LO transitions to Supabase with session boundaries (20-min gap = new session) and duration computation
- **Live class dashboard** at `/live/[courseid]/dashboard`: real-time class health gauge, at-risk alert panel (stuck/thrashing/idle detection using modified Z-score), progress funnel, and filterable student grid with activity sparklines
- **Mock simulator**: Append `?mock=true` to test locally without PartyKit or Supabase — generates 10 fake students with varied behaviors using faker

## New files (12)
- `src/lib/services/community/services/activity-monitor.svelte.ts` — engagement state tracking
- `src/lib/services/community/services/nav-tracker.svelte.ts` — navigation session tracking
- `src/lib/services/community/services/dashboard-aggregator.svelte.ts` — client-side alert engine
- `src/lib/services/community/services/dashboard-mock.ts` — mock simulator for local testing
- `src/lib/ui/dashboard/` — ClassHealthGauge, AlertPanel, ProgressFunnel, StudentStateGrid, ActivitySparkline
- `src/routes/(live)/live/[courseid]/dashboard/` — dashboard route (+page.ts, +page.svelte)
- `supabase/migrations/001_create_nav_events.sql` — nav events table

## Modified files (10)
- `types.svelte.ts` — EngagementState type, dashboard types on LoRecord/LoUser
- `presence.svelte.ts` — broadcast engagement state + heartbeat
- `connect.svelte.ts` — 30s heartbeat, activity monitor + nav tracker hooks
- `supabase-client.ts` — insertNavEvent, getNavEventsByCourse
- `fluent-icons.ts` — dashboard/engagement icons
- `en.ts` — dashboard i18n keys
- `ConnectedProfile.svelte` — Class Dashboard menu link
- `StudentCard.svelte` — engagement indicator dot
- `+layout.svelte` — stopTimer cleanup on destroy
- `index.ts` — barrel exports

## Test plan

- [ ] Run `npm run dev`, open `/live/<courseid>/dashboard?mock=true`
- [ ] Verify 10 fake students populate the grid with engagement dots
- [ ] Verify class health gauge shows active/idle/away distribution
- [ ] Wait 30-60s — thrashing and stuck alerts should fire
- [ ] Filter tabs (Active/Idle/Away) show correct counts
- [ ] Dismiss alerts — respect 5-alert cap and 2-min cooldown
- [ ] Remove `?mock=true` — verify real mode connects to PartyKit
- [ ] Existing `/live/[courseid]` page unchanged
- [ ] `npx svelte-check` — no new errors beyond pre-existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)