### PR TITLE
Add LICENSE, SECURITY.md, and npm audit CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       - name: Run linter
         run: npm run lint
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Tutors SDK Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 15.2.x  | :white_check_mark: |
+| < 15.2  | :x:                |
+
+Only the latest release on the `development` branch is actively supported with security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Tutors, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use [GitHub Security Advisories](https://github.com/tutors-sdk/tutors/security/advisories/new) to report the vulnerability privately.
+
+### What to include in your report
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any relevant logs, screenshots, or proof-of-concept code
+- The version(s) of Tutors affected
+- Any suggested fix, if available
+
+### Response timeline
+
+- **Initial response**: within 7 business days
+- **Status update**: within 14 business days of the initial report
+- **Resolution**: dependent on severity and complexity
+
+We will work with you to understand and address the issue. Once a fix is available, we will coordinate disclosure with you.
+
+## Security Contacts
+
+This repository is maintained by @edeleastar and @jouwdan. Security reports submitted through GitHub Security Advisories will be reviewed by the maintainers.


### PR DESCRIPTION
## Summary

- **LICENSE**: Add MIT LICENSE file (referenced in README badge but missing from repo)
- **SECURITY.md**: Add vulnerability disclosure policy with GitHub Security Advisories workflow
- **CI**: Add `npm audit --audit-level=high` step to the test workflow for dependency vulnerability scanning

## Context

These are foundational release-readiness items identified during a distribution audit. All three are low-effort, high-impact gaps for an open-source project.

## Test plan

- [ ] Verify LICENSE renders correctly on GitHub repo page
- [ ] Verify SECURITY.md appears under the repo's Security tab
- [ ] Verify CI workflow runs successfully with the new audit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)