### PR TITLE
Update changelog through v15.2.0 and add release notes generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,101 @@
 # Tutors Changelog
 
+> Changelog format updated from v12.0.0 onward. For automated release notes generation,
+> see `guides/Release-Strategy.md`.
+
+## [Unreleased]
+
+## v15.2.0 (2026-07)
+
+### Features
+
+- Interactive notebook cells with solution hiding and Pyodide execution
+- Jupyter Notebook support as a first-class content type
+- Mermaid.js diagram rendering in course content
+- Marp slide presentation support with server-side rendering
+- Internationalization (i18n) support
+- Accessibility improvements across components
+
+### Fixes
+
+- Marp rendering hang resolved by moving to server-side API endpoint
+- Marp detection fix for production course JSON
+- Memory leak fixes and type safety improvements
+- XSS sanitization and security header hardening
+
+### Infrastructure
+
+- Comprehensive testing infrastructure with BDD/EARS and mutation testing (95 tests)
+- Architecture document added
+- Knip integration for unused code detection
+- Loglevel logging system replacing console usage
+- Security review tooling
+
+## v14.0.0 (2025-07)
+
+### Features
+
+- Embedded video player with poster image support
+- YouTube configuration for course content
+- Podcast support and podcast wall view
+- Tree view enhancements with unique nodes and expanded flags
+- Sidebar independent scrolling
+- HTTP protocol support for local hosting
+
+### Fixes
+
+- Breadcrumbs responsive behavior fixes
+- Search result display fixes
+- Lab navigation edge cases resolved
+
+### Infrastructure
+
+- Live view refactor
+- Enrollment system changes
+
+## v13.0.0 (2025-06)
+
+### Features
+
+- Refactor to use JSR tutors model package
+- Export types for external consumption
+- Additional asset types support
+
+### Breaking Changes
+
+- Remove base utils (consumers must migrate to new package)
+- Icon navigation bar types moved to lo-types
+
+## v12.0.0 (2024-01)
+
+### Features
+
+- SvelteKit 2 alignment
+- Skeleton UI v2 to v4 migration
+- Simulator implementation
+- Sentiment system with emojis and status fields
+- Auth rework: Auth0 to Supabase session management
+- Presence system improvements (PartyKit integration)
+- Student connect users
+- Favorites system
+- Animated footer redesign
+
+### Fixes
+
+- PDF rendering improvements
+- Dark mode prose improvements
+- Lab navigation fixes
+- Various accessibility and ARIA fixes
+- Search improvements (auto-focus, larger click targets)
+- Course visit card improvements
+
+### Infrastructure
+
+- Tailwind configuration updates
+- Package updates and version corrections (v12.2.0)
+
+---
+
 #### [2024-01-09]: Tutors 11.3.0
 
 - Refactor: Services layer restructuring (#920)

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# generate-release-notes.sh
+#
+# Generate release notes from git log between two refs.
+# Groups commits by conventional-commit type and lists merged PRs.
+#
+# Usage:
+#   ./scripts/generate-release-notes.sh <FROM_REF> [TO_REF]
+#
+# Examples:
+#   ./scripts/generate-release-notes.sh v14.0.0 v15.0.0
+#   ./scripts/generate-release-notes.sh v15.0.0          # defaults TO_REF to HEAD
+#
+
+set -euo pipefail
+
+FROM_REF="${1:?Usage: $0 <FROM_REF> [TO_REF]}"
+TO_REF="${2:-HEAD}"
+
+echo "# Release Notes: ${FROM_REF}..${TO_REF}"
+echo ""
+echo "Generated on $(date -u +%Y-%m-%d)"
+echo ""
+
+# Collect all non-merge commit subjects
+commits=$(git log --no-merges --pretty=format:"%s" "${FROM_REF}..${TO_REF}")
+
+print_section() {
+  local title="$1"
+  local pattern="$2"
+  local matches
+
+  matches=$(echo "$commits" | grep -iE "^${pattern}" | sed -E "s/^${pattern}[:(]?\s*//" | sort -u || true)
+
+  if [ -n "$matches" ]; then
+    echo "## ${title}"
+    echo ""
+    while IFS= read -r line; do
+      echo "- ${line}"
+    done <<< "$matches"
+    echo ""
+  fi
+}
+
+print_section "Features" "feat"
+print_section "Bug Fixes" "fix"
+print_section "Refactoring" "refactor"
+print_section "Documentation" "docs"
+print_section "Chores" "chore"
+print_section "Tests" "test"
+
+# List merged PRs
+prs=$(git log --merges --pretty=format:"%s" "${FROM_REF}..${TO_REF}" | grep -i "Merge pull request" || true)
+
+if [ -n "$prs" ]; then
+  echo "## Merged Pull Requests"
+  echo ""
+  while IFS= read -r line; do
+    echo "- ${line}"
+  done <<< "$prs"
+  echo ""
+fi
+
+# Catch-all: commits that don't match any conventional-commit prefix
+other=$(echo "$commits" | grep -ivE "^(feat|fix|refactor|docs|chore|test)" | head -50 || true)
+
+if [ -n "$other" ]; then
+  echo "## Other Changes"
+  echo ""
+  while IFS= read -r line; do
+    if [ -n "$line" ]; then
+      echo "- ${line}"
+    fi
+  done <<< "$other"
+  echo ""
+fi


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Backfill entries from v12.0.0 through v15.2.0, covering four major versions that were undocumented. Uses a modernized format (## versions, ### categories) going forward while preserving existing entries.
- **scripts/generate-release-notes.sh**: Add a simple shell script that generates release notes from git log between two refs, grouped by conventional-commit type (feat/fix/refactor/docs/chore/test) and merged PRs.

## Changelog Versions Added

| Version | Period | Highlights |
|---------|--------|------------|
| v15.2.0 | 2025-12 to present | Notebooks, Mermaid/Marp, i18n, testing infra, security hardening |
| v14.0.0 | 2025-07 to 2025-11 | Video/podcast, tree view, sidebar, live view refactor |
| v13.0.0 | 2025-06 | JSR tutors model, exported types, breaking: base utils removal |
| v12.0.0 | 2024-01 to 2025-05 | SvelteKit 2, Skeleton v4, auth rework, sentiment, favorites |

## Test plan

- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Verify existing changelog entries (v11.3.0 and earlier) are preserved
- [ ] Test release notes script: `./scripts/generate-release-notes.sh HEAD~20 HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)