### PR TITLE
Add quiz learning object type with live and async quiz support

### DIFF
--- a/src/lib/services/community/services/presence.svelte.ts
+++ b/src/lib/services/community/services/presence.svelte.ts
@@ -32,6 +32,12 @@ export const presenceService: PresenceService = {
     } catch {
       return;
     }
+
+    if (nextCourseEvent.type === "quiz:live-started") {
+      this.onQuizStarted?.(nextCourseEvent);
+      return;
+    }
+
     // Only process events for current course and from other users
     if (nextCourseEvent.courseId === this.listeningTo) {
       // && nextCourseEvent.user.id !== tutorsId.value?.login) {

--- a/src/lib/services/community/types.svelte.ts
+++ b/src/lib/services/community/types.svelte.ts
@@ -83,6 +83,8 @@ export interface PresenceService {
    * @param courseId - Identifier of course to monitor
    */
   startPresenceListener(courseId: string): void;
+
+  onQuizStarted?: ((notification: any) => void) | undefined;
 }
 
 /**

--- a/src/lib/services/connect/index.ts
+++ b/src/lib/services/connect/index.ts
@@ -5,4 +5,4 @@
 
 export { tutorsConnectService } from "./services/connect.svelte";
 export type { TutorsId, CourseVisit, CourseSentimentId } from "./types";
-export { COURSE_SENTIMENT_IDS } from "./types";
+export { COURSE_SENTIMENT_IDS, trackableLoTypes } from "./types";

--- a/src/lib/services/connect/types.ts
+++ b/src/lib/services/connect/types.ts
@@ -3,6 +3,8 @@ import type { Course, IconType } from "@tutors/tutors-model-lib";
 export const COURSE_SENTIMENT_IDS = ["neutral", "fine", "delighted", "confident", "overwhelmed", "confused", "drained"] as const;
 export type CourseSentimentId = (typeof COURSE_SENTIMENT_IDS)[number];
 
+export const trackableLoTypes = ["lab", "talk", "note", "paneltalk", "panelnote", "panelvideo", "book", "tutorial", "notebook", "quiz"] as const;
+
 /**
  * Record of a user's interaction with a course
  */

--- a/src/lib/services/course/services/course.svelte.ts
+++ b/src/lib/services/course/services/course.svelte.ts
@@ -22,6 +22,8 @@ export const courseService: CourseService = {
   notes: new Map<string, Note>(),
   /** Cache of live notebook instances indexed by notebookId */
   notebooks: new Map<string, LiveNotebook>(),
+  /** Cache of processed quizzes indexed by route */
+  quizzes: new Map<string, Lo>(),
   /** Current course URL */
   courseUrl: rune(""),
 
@@ -173,6 +175,11 @@ export const courseService: CourseService = {
         markdownService.convertNotebookToHtml(course, lo);
         const liveNotebook = new LiveNotebook(course, lo as NotebookLo, loId);
         this.notebooks.set(loId, liveNotebook);
+      }
+    }
+    if (lo?.type === "quiz") {
+      if (!this.quizzes.has(loId)) {
+        this.quizzes.set(loId, lo);
       }
     }
     return lo ?? course;

--- a/src/lib/services/course/services/lo-tree.ts
+++ b/src/lib/services/course/services/lo-tree.ts
@@ -56,7 +56,19 @@ export function decorateCourseTree(course: Course, courseId: string = "", course
   loadPropertyFlags(course);
   createCompanions(course);
   createWalls(course);
-  // createToc(course);
+
+  const quizLos = filterByType(allLos, "quiz").filter((lo) => !lo.hide);
+  if (quizLos.length > 0) {
+    course.walls?.push(quizLos);
+    course.wallMap?.set("quiz", quizLos);
+    course.wallBar?.bar?.push({
+      link: `/wall/quiz/${course.courseId}`,
+      type: "quiz",
+      tip: "All quizzes in the course",
+      target: ""
+    });
+  }
+
   initCalendar(course);
 }
 
@@ -75,7 +87,7 @@ function decorateLoTree(course: Course, lo: Lo) {
   }
 
   // Convert contentMd to html
-  if (lo.type !== "lab" && lo.type !== "note" && lo.type !== "notebook") {
+  if (lo.type !== "lab" && lo.type !== "note" && lo.type !== "notebook" && lo.type !== "quiz") {
     // Convert labs, notes & notebooks on demand as can be time consuming to convert all at once
     convertLoToHtml(course, lo);
   }

--- a/src/lib/services/course/types.ts
+++ b/src/lib/services/course/types.ts
@@ -68,6 +68,8 @@ export interface CourseService {
   notes: Map<string, Note>;
   /** Cache of live notebook instances */
   notebooks: Map<string, NotebookService>;
+  /** Cache of processed quizzes */
+  quizzes: Map<string, Lo>;
   /** Current course URL */
   courseUrl: any;
 

--- a/src/lib/services/markdown/services/markdown.svelte.ts
+++ b/src/lib/services/markdown/services/markdown.svelte.ts
@@ -113,6 +113,10 @@ markdownIt.renderer.rules.fence = (tokens, idx, options, env, self) => {
     const escaped = token.content.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     return `<div class="mermaid">${escaped}</div>`;
   }
+  if (token.info.trim() === "quiz") {
+    const escaped = token.content.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return `<div class="quiz-definition" data-quiz-source="${escaped}"></div>`;
+  }
   return defaultFence(tokens, idx, options, env, self);
 };
 

--- a/src/lib/services/quiz/index.ts
+++ b/src/lib/services/quiz/index.ts
@@ -1,0 +1,39 @@
+export { quizSessionState } from "./services/quiz-session.svelte";
+export {
+  createQuiz,
+  updateQuiz,
+  getQuizzesByCourse,
+  getQuizById,
+  publishQuiz,
+  archiveQuiz,
+  createSession,
+  updateSessionStatus,
+  getActiveSession,
+  getSessionById,
+  endSession,
+  submitResponse,
+  getResponsesForSession,
+  getResponsesForQuestion,
+  getResponsesForQuiz,
+  getAsyncResponses,
+  computeQuestionAnalytics,
+  seedRemoteSession,
+  seedRemoteQuiz
+} from "./services/quiz.svelte";
+export { isLecturer, isQuizEnabled, getQuizUserId, getQuizUserName, getQuizUserAvatar } from "./utils";
+export type {
+  Quiz,
+  QuizQuestion,
+  QuizSession,
+  QuizResponse,
+  QuizMessage,
+  QuizQuestionMessage,
+  QuizAnswerMessage,
+  QuizRevealMessage,
+  QuizLiveStartedNotification,
+  QuestionAnalytics,
+  QuestionType,
+  QuizSource,
+  QuizStatus,
+  SessionStatus
+} from "./types";

--- a/src/lib/services/quiz/services/quiz-action.ts
+++ b/src/lib/services/quiz/services/quiz-action.ts
@@ -1,0 +1,80 @@
+import type { ActionReturn } from "svelte/action";
+import { parseQuizMarkdown } from "./quiz-parser";
+
+export function quizify(node: HTMLElement): ActionReturn {
+  renderQuizBlocks(node);
+  return {
+    update() {
+      requestAnimationFrame(() => renderQuizBlocks(node));
+    },
+    destroy() {}
+  };
+}
+
+function renderQuizBlocks(container: HTMLElement) {
+  const nodes = container.querySelectorAll<HTMLElement>("div.quiz-definition");
+  if (nodes.length === 0) return;
+
+  for (const node of nodes) {
+    if (node.dataset.quizRendered) continue;
+    node.dataset.quizRendered = "true";
+
+    const source = decodeHtmlEntities(node.dataset.quizSource || "");
+    if (!source) continue;
+
+    const parsed = parseQuizMarkdown(source);
+    if (!parsed) {
+      node.innerHTML = `<p class="text-error-500 text-sm">Invalid quiz format</p>`;
+      continue;
+    }
+
+    const courseId = extractCourseIdFromUrl();
+    node.innerHTML = "";
+    node.className = "quiz-embed border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 my-4";
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "flex items-center justify-between";
+
+    const info = document.createElement("div");
+    info.innerHTML = `
+      <h3 class="font-medium text-lg">${escapeHtml(parsed.title)}</h3>
+      <p class="text-sm text-surface-500">
+        ${parsed.questions.length} question${parsed.questions.length !== 1 ? "s" : ""}
+        ${parsed.timeLimit ? ` &middot; ${parsed.timeLimit}s per question` : ""}
+      </p>
+    `;
+
+    const link = document.createElement("a");
+    link.href = `/quiz/${courseId}`;
+    link.className = "px-4 py-2 rounded-lg text-sm font-medium preset-filled-primary-500 no-underline";
+    link.textContent = "Open Quiz";
+    link.dataset.quizTitle = parsed.title;
+    link.dataset.quizData = JSON.stringify(parsed);
+
+    wrapper.appendChild(info);
+    wrapper.appendChild(link);
+    node.appendChild(wrapper);
+  }
+}
+
+function extractCourseIdFromUrl(): string {
+  const path = window.location.pathname;
+  const segments = path.split("/").filter(Boolean);
+  const routeTypes = ["course", "topic", "lab", "talk", "note", "video", "notebook", "tutorial", "paneltalk", "wall", "search", "quiz", "time", "llm", "live"];
+  for (let i = 0; i < segments.length; i++) {
+    if (routeTypes.includes(segments[i]) && i + 1 < segments.length) {
+      return segments[i + 1];
+    }
+  }
+  return segments[1] ?? "";
+}
+
+function decodeHtmlEntities(str: string): string {
+  const textarea = document.createElement("textarea");
+  textarea.innerHTML = str;
+  return textarea.value;
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/src/lib/services/quiz/services/quiz-parser.ts
+++ b/src/lib/services/quiz/services/quiz-parser.ts
@@ -1,0 +1,99 @@
+import type { QuizQuestion, QuestionType } from "../types";
+
+export interface ParsedQuiz {
+  title: string;
+  timeLimit: number | null;
+  questions: QuizQuestion[];
+}
+
+export function parseQuizMarkdown(source: string): ParsedQuiz | null {
+  const sections = source.split(/^---$/m).map((s) => s.trim()).filter(Boolean);
+  if (sections.length === 0) return null;
+
+  const headerSection = sections[0];
+  const title = extractField(headerSection, "title") ?? "Untitled Quiz";
+  const timeLimitStr = extractField(headerSection, "time_limit");
+  const timeLimit = timeLimitStr ? parseInt(timeLimitStr, 10) : null;
+
+  const hasQuestionFields = headerSection.includes("type:") && headerSection.includes("text:");
+  const questionSections = hasQuestionFields ? sections : sections.slice(1);
+
+  const questions: QuizQuestion[] = [];
+  for (let i = 0; i < questionSections.length; i++) {
+    const section = questionSections[i];
+    const question = parseQuestionSection(section, i);
+    if (question) {
+      questions.push(question);
+    }
+  }
+
+  if (questions.length === 0) return null;
+
+  return { title, timeLimit, questions };
+}
+
+function parseQuestionSection(section: string, index: number): QuizQuestion | null {
+  const typeStr = extractField(section, "type");
+  const text = extractField(section, "text");
+  const correctStr = extractField(section, "correct");
+
+  if (!text) return null;
+
+  const type: QuestionType = typeStr === "true-false" ? "true-false" : "multiple-choice";
+
+  let options: string[];
+  if (type === "true-false") {
+    options = ["True", "False"];
+  } else {
+    options = extractListField(section, "options");
+    if (options.length < 2) return null;
+  }
+
+  let correctIndex = 0;
+  if (correctStr !== null) {
+    if (type === "true-false") {
+      correctIndex = correctStr.toLowerCase() === "false" || correctStr === "1" ? 1 : 0;
+    } else {
+      correctIndex = parseInt(correctStr, 10) || 0;
+    }
+  }
+
+  return {
+    id: `q${index + 1}`,
+    type,
+    text,
+    options,
+    correctIndex: Math.min(correctIndex, options.length - 1)
+  };
+}
+
+function extractField(section: string, key: string): string | null {
+  const regex = new RegExp(`^${key}:\\s*(.+)$`, "mi");
+  const match = section.match(regex);
+  return match ? match[1].trim().replace(/^["']|["']$/g, "") : null;
+}
+
+function extractListField(section: string, key: string): string[] {
+  const lines = section.split("\n");
+  const items: string[] = [];
+  let inList = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.toLowerCase().startsWith(`${key}:`)) {
+      inList = true;
+      continue;
+    }
+    if (inList) {
+      if (trimmed.startsWith("- ")) {
+        items.push(trimmed.slice(2).trim().replace(/^["']|["']$/g, ""));
+      } else if (trimmed && !trimmed.includes(":")) {
+        items.push(trimmed.replace(/^["']|["']$/g, ""));
+      } else {
+        inList = false;
+      }
+    }
+  }
+
+  return items;
+}

--- a/src/lib/services/quiz/services/quiz-session.svelte.ts
+++ b/src/lib/services/quiz/services/quiz-session.svelte.ts
@@ -1,0 +1,184 @@
+import PartySocket from "partysocket";
+import { PUBLIC_party_kit_main_room } from "$env/static/public";
+import { rune } from "$lib/runes.svelte";
+import type {
+  QuizMessage,
+  QuizQuestionMessage,
+  QuizAnswerMessage,
+  QuizRevealMessage,
+  QuizJoinMessage
+} from "../types";
+
+const partyKitServer = PUBLIC_party_kit_main_room;
+
+export interface QuizParticipant {
+  id: string;
+  name: string;
+  avatar: string;
+}
+
+export const quizSessionState = {
+  participants: rune<Map<string, QuizParticipant>>(new Map()),
+  participantCount: rune(0),
+  currentQuestion: rune<QuizQuestionMessage | null>(null),
+  answers: rune<QuizAnswerMessage[]>([]),
+  revealData: rune<QuizRevealMessage | null>(null),
+  sessionEnded: rune(false),
+  isConnected: rune(false),
+
+  socket: null as PartySocket | null,
+  broadcastChannel: null as BroadcastChannel | null,
+
+  connect(courseId: string, sessionId: string) {
+    this.reset();
+
+    const channelName = `quiz-session-${courseId}-${sessionId}`;
+    try {
+      this.broadcastChannel = new BroadcastChannel(channelName);
+      this.broadcastChannel.onmessage = (event) => {
+        if (event.data) this.handleMessage({ data: JSON.stringify(event.data) } as MessageEvent);
+      };
+      this.isConnected.value = true;
+    } catch { /* BroadcastChannel unavailable */ }
+
+    if (partyKitServer === "XXX") return;
+
+    this.socket = new PartySocket({
+      host: partyKitServer,
+      room: `quiz-${courseId}-${sessionId}`
+    });
+    this.socket.addEventListener("message", this.handleMessage.bind(this));
+    this.isConnected.value = true;
+  },
+
+  disconnect() {
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.broadcastChannel) {
+      this.broadcastChannel.close();
+      this.broadcastChannel = null;
+    }
+    this.isConnected.value = false;
+  },
+
+  reset() {
+    this.participants.value = new Map();
+    this.participantCount.value = 0;
+    this.currentQuestion.value = null;
+    this.answers.value = [];
+    this.revealData.value = null;
+    this.sessionEnded.value = false;
+  },
+
+  sendMessage(msg: QuizMessage) {
+    if (this.socket) {
+      this.socket.send(JSON.stringify(msg));
+    }
+    if (this.broadcastChannel) {
+      try {
+        this.broadcastChannel.postMessage(JSON.parse(JSON.stringify(msg)));
+      } catch { /* BroadcastChannel send failed */ }
+    }
+  },
+
+  // Lecturer actions
+  pushQuestion(questionIndex: number, text: string, options: string[], questionType: "multiple-choice" | "true-false", timeLimit: number | null) {
+    this.answers.value = [];
+    this.revealData.value = null;
+    const msg: QuizQuestionMessage = {
+      type: "quiz:question",
+      questionIndex,
+      text,
+      options,
+      questionType,
+      timeLimit
+    };
+    this.currentQuestion.value = msg;
+    this.sendMessage(msg);
+  },
+
+  revealAnswer(questionIndex: number, correctIndex: number, distribution: number[]) {
+    const msg: QuizRevealMessage = {
+      type: "quiz:reveal",
+      questionIndex,
+      correctIndex,
+      distribution
+    };
+    this.revealData.value = msg;
+    this.sendMessage(msg);
+  },
+
+  endQuiz() {
+    this.sendMessage({ type: "quiz:end" });
+    this.sessionEnded.value = true;
+  },
+
+  // Student actions
+  joinSession(studentId: string, studentName: string, avatar: string) {
+    const msg: QuizJoinMessage = {
+      type: "quiz:join",
+      studentId,
+      studentName,
+      avatar
+    };
+    this.sendMessage(msg);
+  },
+
+  submitAnswer(studentId: string, questionIndex: number, selectedIndex: number, responseTimeMs: number) {
+    const msg: QuizAnswerMessage = {
+      type: "quiz:answer",
+      studentId,
+      questionIndex,
+      selectedIndex,
+      responseTimeMs
+    };
+    this.sendMessage(msg);
+  },
+
+  handleMessage(event: MessageEvent) {
+    const msg: QuizMessage = JSON.parse(event.data);
+
+    switch (msg.type) {
+      case "quiz:join": {
+        const participant: QuizParticipant = {
+          id: msg.studentId,
+          name: msg.studentName,
+          avatar: msg.avatar
+        };
+        this.participants.value.set(msg.studentId, participant);
+        this.participants.value = new Map(this.participants.value);
+        this.participantCount.value = this.participants.value.size;
+        if (typeof sessionStorage !== "undefined" &&
+          sessionStorage.getItem("quizHostSession") &&
+          this.currentQuestion.value) {
+          this.sendMessage(this.currentQuestion.value);
+        }
+        break;
+      }
+
+      case "quiz:question":
+        this.currentQuestion.value = msg;
+        this.answers.value = [];
+        this.revealData.value = null;
+        break;
+
+      case "quiz:answer":
+        this.answers.value = [...this.answers.value, msg];
+        break;
+
+      case "quiz:reveal":
+        this.revealData.value = msg;
+        break;
+
+      case "quiz:end":
+        this.sessionEnded.value = true;
+        break;
+
+      case "quiz:participant-count":
+        this.participantCount.value = msg.count;
+        break;
+    }
+  }
+};

--- a/src/lib/services/quiz/services/quiz.svelte.ts
+++ b/src/lib/services/quiz/services/quiz.svelte.ts
@@ -1,0 +1,429 @@
+import { supabase } from "$lib/services/community/utils/supabase-client";
+import { PUBLIC_ANON_MODE } from "$env/static/public";
+import type { Quiz, QuizQuestion, QuizResponse, QuizSession, QuestionAnalytics, QuizSource, QuizStatus, SessionStatus } from "../types";
+
+function useSupabase(): boolean {
+  return PUBLIC_ANON_MODE !== "TRUE" && typeof supabase !== "undefined";
+}
+
+// --- In-memory store for local/anon development ---
+
+const memQuizzes: Quiz[] = [];
+const memSessions: QuizSession[] = [];
+const memResponses: QuizResponse[] = [];
+let memIdCounter = 1;
+
+function genId(): string {
+  return `local-${memIdCounter++}-${Date.now().toString(36)}`;
+}
+
+// --- Column mapping (Supabase only) ---
+
+function toQuizRow(quiz: Partial<Quiz>): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  if (quiz.courseId !== undefined) row.course_id = quiz.courseId;
+  if (quiz.title !== undefined) row.title = quiz.title;
+  if (quiz.questions !== undefined) row.questions = quiz.questions;
+  if (quiz.createdBy !== undefined) row.created_by = quiz.createdBy;
+  if (quiz.source !== undefined) row.source = quiz.source;
+  if (quiz.timeLimit !== undefined) row.time_limit = quiz.timeLimit;
+  if (quiz.status !== undefined) row.status = quiz.status;
+  return row;
+}
+
+function fromQuizRow(row: Record<string, unknown>): Quiz {
+  return {
+    id: row.id as string,
+    courseId: row.course_id as string,
+    title: row.title as string,
+    questions: row.questions as QuizQuestion[],
+    createdBy: row.created_by as string,
+    source: row.source as QuizSource,
+    timeLimit: (row.time_limit as number) ?? null,
+    status: row.status as QuizStatus,
+    createdAt: row.created_at as string
+  };
+}
+
+function fromSessionRow(row: Record<string, unknown>): QuizSession {
+  return {
+    id: row.id as string,
+    quizId: row.quiz_id as string,
+    courseId: row.course_id as string,
+    lecturerId: row.lecturer_id as string,
+    status: row.status as SessionStatus,
+    currentQuestion: row.current_question as number,
+    startedAt: row.started_at as string,
+    endedAt: (row.ended_at as string) ?? null
+  };
+}
+
+function fromResponseRow(row: Record<string, unknown>): QuizResponse {
+  return {
+    id: row.id as string,
+    quizId: row.quiz_id as string,
+    sessionId: (row.session_id as string) ?? null,
+    questionId: row.question_id as string,
+    studentId: row.student_id as string,
+    selectedIndex: row.selected_index as number,
+    isCorrect: row.is_correct as boolean,
+    responseTimeMs: row.response_time_ms as number,
+    submittedAt: row.submitted_at as string
+  };
+}
+
+// --- Cross-tab seeding for in-memory mode ---
+
+export function seedRemoteSession(session: QuizSession): void {
+  if (!memSessions.find((s) => s.id === session.id)) {
+    memSessions.push(session);
+  }
+}
+
+export function seedRemoteQuiz(quiz: Quiz): void {
+  if (!memQuizzes.find((q) => q.id === quiz.id)) {
+    memQuizzes.push(quiz);
+  }
+}
+
+// --- Quiz CRUD ---
+
+export async function createQuiz(quiz: Omit<Quiz, "id" | "createdAt">): Promise<Quiz | null> {
+  if (!useSupabase()) {
+    const newQuiz: Quiz = {
+      ...quiz,
+      id: genId(),
+      createdAt: new Date().toISOString()
+    };
+    memQuizzes.push(newQuiz);
+    return newQuiz;
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quizzes")
+    .insert(toQuizRow(quiz))
+    .select()
+    .single();
+
+  if (error) {
+    console.error("createQuiz failed:", error);
+    return null;
+  }
+  return fromQuizRow(data);
+}
+
+export async function updateQuiz(id: string, updates: Partial<Pick<Quiz, "title" | "questions" | "timeLimit" | "status">>): Promise<void> {
+  if (!useSupabase()) {
+    const quiz = memQuizzes.find((q) => q.id === id);
+    if (quiz) Object.assign(quiz, updates);
+    return;
+  }
+
+  const row: Record<string, unknown> = {};
+  if (updates.title !== undefined) row.title = updates.title;
+  if (updates.questions !== undefined) row.questions = updates.questions;
+  if (updates.timeLimit !== undefined) row.time_limit = updates.timeLimit;
+  if (updates.status !== undefined) row.status = updates.status;
+
+  const { error } = await supabase
+    .from("tutors_quizzes")
+    .update(row)
+    .eq("id", id);
+
+  if (error) {
+    console.error("updateQuiz failed:", error);
+  }
+}
+
+export async function getQuizzesByCourse(courseId: string): Promise<Quiz[]> {
+  if (!useSupabase()) {
+    return memQuizzes.filter((q) => q.courseId === courseId).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quizzes")
+    .select("*")
+    .eq("course_id", courseId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("getQuizzesByCourse failed:", error);
+    return [];
+  }
+  return (data ?? []).map(fromQuizRow);
+}
+
+export async function getQuizById(id: string): Promise<Quiz | null> {
+  if (!useSupabase()) {
+    return memQuizzes.find((q) => q.id === id) ?? null;
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quizzes")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getQuizById failed:", error);
+    return null;
+  }
+  return data ? fromQuizRow(data) : null;
+}
+
+export async function publishQuiz(id: string): Promise<void> {
+  await updateQuiz(id, { status: "published" });
+}
+
+export async function archiveQuiz(id: string): Promise<void> {
+  await updateQuiz(id, { status: "archived" });
+}
+
+// --- Session management ---
+
+export async function createSession(quizId: string, courseId: string, lecturerId: string): Promise<QuizSession | null> {
+  if (!useSupabase()) {
+    const session: QuizSession = {
+      id: genId(),
+      quizId,
+      courseId,
+      lecturerId,
+      status: "waiting",
+      currentQuestion: 0,
+      startedAt: new Date().toISOString(),
+      endedAt: null
+    };
+    memSessions.push(session);
+    return session;
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_sessions")
+    .insert({
+      quiz_id: quizId,
+      course_id: courseId,
+      lecturer_id: lecturerId,
+      status: "waiting",
+      current_question: 0
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("createSession failed:", error);
+    return null;
+  }
+  return fromSessionRow(data);
+}
+
+export async function updateSessionStatus(sessionId: string, status: SessionStatus, currentQuestion?: number): Promise<void> {
+  if (!useSupabase()) {
+    const session = memSessions.find((s) => s.id === sessionId);
+    if (session) {
+      session.status = status;
+      if (currentQuestion !== undefined) session.currentQuestion = currentQuestion;
+      if (status === "completed") session.endedAt = new Date().toISOString();
+    }
+    return;
+  }
+
+  const row: Record<string, unknown> = { status };
+  if (currentQuestion !== undefined) row.current_question = currentQuestion;
+  if (status === "completed") row.ended_at = new Date().toISOString();
+
+  const { error } = await supabase
+    .from("tutors_quiz_sessions")
+    .update(row)
+    .eq("id", sessionId);
+
+  if (error) {
+    console.error("updateSessionStatus failed:", error);
+  }
+}
+
+export async function getActiveSession(courseId: string): Promise<QuizSession | null> {
+  if (!useSupabase()) {
+    return memSessions.find(
+      (s) => s.courseId === courseId && ["waiting", "active", "reviewing"].includes(s.status)
+    ) ?? null;
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_sessions")
+    .select("*")
+    .eq("course_id", courseId)
+    .in("status", ["waiting", "active", "reviewing"])
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getActiveSession failed:", error);
+    return null;
+  }
+  return data ? fromSessionRow(data) : null;
+}
+
+export async function getSessionById(sessionId: string): Promise<QuizSession | null> {
+  if (!useSupabase()) {
+    return memSessions.find((s) => s.id === sessionId) ?? null;
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_sessions")
+    .select("*")
+    .eq("id", sessionId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("getSessionById failed:", error);
+    return null;
+  }
+  return data ? fromSessionRow(data) : null;
+}
+
+export async function endSession(sessionId: string): Promise<void> {
+  await updateSessionStatus(sessionId, "completed");
+}
+
+// --- Responses ---
+
+export async function submitResponse(response: Omit<QuizResponse, "id" | "submittedAt">): Promise<void> {
+  if (!useSupabase()) {
+    const existing = memResponses.findIndex(
+      (r) => r.quizId === response.quizId && r.questionId === response.questionId && r.studentId === response.studentId && r.sessionId === response.sessionId
+    );
+    const full: QuizResponse = { ...response, id: genId(), submittedAt: new Date().toISOString() };
+    if (existing >= 0) {
+      memResponses[existing] = full;
+    } else {
+      memResponses.push(full);
+    }
+    return;
+  }
+
+  const row: Record<string, unknown> = {
+    quiz_id: response.quizId,
+    question_id: response.questionId,
+    student_id: response.studentId,
+    selected_index: response.selectedIndex,
+    is_correct: response.isCorrect,
+    response_time_ms: response.responseTimeMs
+  };
+  if (response.sessionId) {
+    row.session_id = response.sessionId;
+  }
+
+  const { error } = await supabase
+    .from("tutors_quiz_responses")
+    .upsert(row, {
+      onConflict: response.sessionId
+        ? "quiz_id,session_id,question_id,student_id"
+        : "quiz_id,question_id,student_id"
+    });
+
+  if (error) {
+    console.error("submitResponse failed:", error);
+  }
+}
+
+export async function getResponsesForSession(sessionId: string): Promise<QuizResponse[]> {
+  if (!useSupabase()) {
+    return memResponses.filter((r) => r.sessionId === sessionId);
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_responses")
+    .select("*")
+    .eq("session_id", sessionId);
+
+  if (error) {
+    console.error("getResponsesForSession failed:", error);
+    return [];
+  }
+  return (data ?? []).map(fromResponseRow);
+}
+
+export async function getResponsesForQuestion(sessionId: string, questionId: string): Promise<QuizResponse[]> {
+  if (!useSupabase()) {
+    return memResponses.filter((r) => r.sessionId === sessionId && r.questionId === questionId);
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_responses")
+    .select("*")
+    .eq("session_id", sessionId)
+    .eq("question_id", questionId);
+
+  if (error) {
+    console.error("getResponsesForQuestion failed:", error);
+    return [];
+  }
+  return (data ?? []).map(fromResponseRow);
+}
+
+export async function getAsyncResponses(quizId: string, studentId: string): Promise<QuizResponse[]> {
+  if (!useSupabase()) {
+    return memResponses.filter((r) => r.quizId === quizId && r.studentId === studentId && r.sessionId === null);
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_responses")
+    .select("*")
+    .eq("quiz_id", quizId)
+    .eq("student_id", studentId)
+    .is("session_id", null);
+
+  if (error) {
+    console.error("getAsyncResponses failed:", error);
+    return [];
+  }
+  return (data ?? []).map(fromResponseRow);
+}
+
+export async function getResponsesForQuiz(quizId: string): Promise<QuizResponse[]> {
+  if (!useSupabase()) {
+    return memResponses.filter((r) => r.quizId === quizId);
+  }
+
+  const { data, error } = await supabase
+    .from("tutors_quiz_responses")
+    .select("*")
+    .eq("quiz_id", quizId);
+
+  if (error) {
+    console.error("getResponsesForQuiz failed:", error);
+    return [];
+  }
+  return (data ?? []).map(fromResponseRow);
+}
+
+// --- Analytics (pure computation) ---
+
+export function computeQuestionAnalytics(responses: QuizResponse[], questions: QuizQuestion[]): QuestionAnalytics[] {
+  return questions.map((question, index) => {
+    const questionResponses = responses.filter((r) => r.questionId === question.id);
+    const totalResponses = questionResponses.length;
+    const correctCount = questionResponses.filter((r) => r.isCorrect).length;
+    const times = questionResponses.map((r) => r.responseTimeMs);
+
+    const distribution = new Array(question.options.length).fill(0);
+    for (const r of questionResponses) {
+      if (r.selectedIndex >= 0 && r.selectedIndex < distribution.length) {
+        distribution[r.selectedIndex]++;
+      }
+    }
+
+    return {
+      questionIndex: index,
+      questionId: question.id,
+      totalResponses,
+      correctCount,
+      incorrectCount: totalResponses - correctCount,
+      distribution,
+      avgResponseTimeMs: totalResponses > 0 ? Math.round(times.reduce((a, b) => a + b, 0) / totalResponses) : 0,
+      fastestResponseMs: totalResponses > 0 ? Math.min(...times) : 0,
+      slowestResponseMs: totalResponses > 0 ? Math.max(...times) : 0
+    };
+  });
+}

--- a/src/lib/services/quiz/types.ts
+++ b/src/lib/services/quiz/types.ts
@@ -1,0 +1,119 @@
+export type QuestionType = "multiple-choice" | "true-false";
+
+export interface QuizQuestion {
+  id: string;
+  type: QuestionType;
+  text: string;
+  options: string[];
+  correctIndex: number;
+}
+
+export type QuizSource = "course" | "dynamic";
+export type QuizStatus = "draft" | "published" | "archived";
+
+export interface Quiz {
+  id: string;
+  courseId: string;
+  title: string;
+  questions: QuizQuestion[];
+  createdBy: string;
+  source: QuizSource;
+  timeLimit: number | null;
+  status: QuizStatus;
+  createdAt: string;
+}
+
+export type SessionStatus = "waiting" | "active" | "reviewing" | "completed";
+
+export interface QuizSession {
+  id: string;
+  quizId: string;
+  courseId: string;
+  lecturerId: string;
+  status: SessionStatus;
+  currentQuestion: number;
+  startedAt: string;
+  endedAt: string | null;
+}
+
+export interface QuizResponse {
+  id: string;
+  quizId: string;
+  sessionId: string | null;
+  questionId: string;
+  studentId: string;
+  selectedIndex: number;
+  isCorrect: boolean;
+  responseTimeMs: number;
+  submittedAt: string;
+}
+
+export interface QuizJoinMessage {
+  type: "quiz:join";
+  studentId: string;
+  studentName: string;
+  avatar: string;
+}
+
+export interface QuizQuestionMessage {
+  type: "quiz:question";
+  questionIndex: number;
+  text: string;
+  options: string[];
+  questionType: QuestionType;
+  timeLimit: number | null;
+}
+
+export interface QuizAnswerMessage {
+  type: "quiz:answer";
+  studentId: string;
+  questionIndex: number;
+  selectedIndex: number;
+  responseTimeMs: number;
+}
+
+export interface QuizRevealMessage {
+  type: "quiz:reveal";
+  questionIndex: number;
+  correctIndex: number;
+  distribution: number[];
+}
+
+export interface QuizEndMessage {
+  type: "quiz:end";
+}
+
+export interface QuizParticipantCountMessage {
+  type: "quiz:participant-count";
+  count: number;
+}
+
+export type QuizMessage =
+  | QuizJoinMessage
+  | QuizQuestionMessage
+  | QuizAnswerMessage
+  | QuizRevealMessage
+  | QuizEndMessage
+  | QuizParticipantCountMessage;
+
+export interface QuizLiveStartedNotification {
+  type: "quiz:live-started";
+  sessionId: string;
+  quizTitle: string;
+  courseId: string;
+  lecturerName: string;
+  quiz?: Quiz;
+  session?: QuizSession;
+}
+
+export interface QuestionAnalytics {
+  questionIndex: number;
+  questionId: string;
+  totalResponses: number;
+  correctCount: number;
+  incorrectCount: number;
+  distribution: number[];
+  avgResponseTimeMs: number;
+  fastestResponseMs: number;
+  slowestResponseMs: number;
+}

--- a/src/lib/services/quiz/utils.ts
+++ b/src/lib/services/quiz/utils.ts
@@ -1,0 +1,41 @@
+import { PUBLIC_ANON_MODE } from "$env/static/public";
+import type { Course } from "@tutors/tutors-model-lib";
+import { tutorsId } from "$lib/runes.svelte";
+
+export function isLecturer(course: Course | null, login: string | undefined): boolean {
+  if (!course) return false;
+  // In anon mode, everyone is treated as a lecturer for local testing
+  if (PUBLIC_ANON_MODE === "TRUE") return true;
+  if (!login) return false;
+  const lecturers = course.properties?.lecturers;
+  if (!lecturers) return false;
+  return lecturers
+    .split(",")
+    .map((s: string) => s.trim().toLowerCase())
+    .includes(login.toLowerCase());
+}
+
+export function isQuizEnabled(course: Course | null): boolean {
+  if (!course) return false;
+  if (PUBLIC_ANON_MODE === "TRUE") return true;
+  return !!course.properties?.lecturers;
+}
+
+export function getQuizUserId(): string {
+  if (tutorsId.value?.login) return tutorsId.value.login;
+  if (typeof window !== "undefined") {
+    if (!window.localStorage.quizAnonId) {
+      window.localStorage.quizAnonId = "anon-" + Math.random().toString(36).slice(2, 10);
+    }
+    return window.localStorage.quizAnonId;
+  }
+  return "anon";
+}
+
+export function getQuizUserName(): string {
+  return tutorsId.value?.name ?? "Anonymous";
+}
+
+export function getQuizUserAvatar(): string {
+  return tutorsId.value?.image ?? "https://tutors.dev/logo.svg";
+}

--- a/src/lib/services/themes/icons/easter-icons.ts
+++ b/src/lib/services/themes/icons/easter-icons.ts
@@ -22,6 +22,7 @@ export const EasterIcons: IconLib = {
   lab: { type: "fluent:beaker-24-filled", color: "error" },
   note: { type: "fluent:notepad-16-regular", color: "success" },
   notebook: { type: "simple-icons:jupyter", color: "error" },
+  quiz: { type: "fluent:quiz-new-24-filled", color: "primary" },
   archive: { type: "mdi:basket-outline", color: "error" },
   web: { type: "fluent:bookmark-24-regular", color: "primary" },
   github: { type: "mdi:github", color: "warning" },

--- a/src/lib/services/themes/icons/festive-icons.ts
+++ b/src/lib/services/themes/icons/festive-icons.ts
@@ -22,6 +22,7 @@ export const FestiveIcons: IconLib = {
   lab: { type: "fluent:beaker-24-filled", color: "error" },
   note: { type: "fluent:notepad-16-regular", color: "success" },
   notebook: { type: "simple-icons:jupyter", color: "error" },
+  quiz: { type: "fluent:quiz-new-24-filled", color: "primary" },
   archive: { type: "fluent:archive-24-filled", color: "error" },
   web: { type: "noto:star", color: "primary" },
   github: { type: "mdi:github", color: "warning" },

--- a/src/lib/services/themes/icons/fluent-icons.ts
+++ b/src/lib/services/themes/icons/fluent-icons.ts
@@ -72,6 +72,11 @@ export const FluentIconLib: IconLib = {
   theme: { type: "fluent:color-fill-24-regular", color: "success" },
   codeTheme: { type: "fluent:paint-brush-sparkle-20-regular", color: "primary" },
 
+  // quiz
+  quiz: { type: "fluent:quiz-new-24-filled", color: "primary" },
+  quizLive: { type: "fluent:live-24-filled", color: "error" },
+  quizResults: { type: "fluent:data-bar-vertical-24-filled", color: "success" },
+
   // sentiment
   neutral: { type: "twemoji:dizzy", color: "bg-base-content" },
   fine: { type: "twemoji:slightly-smiling-face", color: "bg-base-content" },

--- a/src/lib/services/themes/icons/hero-icons.ts
+++ b/src/lib/services/themes/icons/hero-icons.ts
@@ -27,6 +27,7 @@ export const HeroIconLib: IconLib = {
   paneltalk: { type: "heroicons-outline:presentation-chart-bar", color: "primary" },
   note: { type: "heroicons:document-text", color: "warning" },
   notebook: { type: "simple-icons:jupyter", color: "success" },
+  quiz: { type: "heroicons:question-mark-circle", color: "primary" },
   panelnote: { type: "heroicons:document-text", color: "warning" },
 
   // pdf reader icons

--- a/src/lib/stores/toaster.ts
+++ b/src/lib/stores/toaster.ts
@@ -1,0 +1,8 @@
+import { createToaster } from "@skeletonlabs/skeleton-svelte";
+
+export const toaster = createToaster({
+  placement: "top-end",
+  overlap: true,
+  gap: 16,
+  duration: 8000
+});

--- a/src/lib/ui/learning-objects/content/Note.svelte
+++ b/src/lib/ui/learning-objects/content/Note.svelte
@@ -3,6 +3,7 @@
   import { currentCodeTheme } from "$lib/services/markdown";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
+  import { quizify } from "$lib/services/quiz/services/quiz-action";
   import type { Lo } from "@tutors/tutors-model-lib";
   import { onDestroy, onMount } from "svelte";
   import { sanitizeHtml } from "$lib/utils/sanitize";
@@ -20,7 +21,7 @@
   });
 </script>
 
-<article class="prose dark:prose-invert mr-4 max-w-none overflow-x-auto" use:mermaidify use:copyCode>
+<article class="prose dark:prose-invert mr-4 max-w-none overflow-x-auto" use:mermaidify use:copyCode use:quizify>
   {#key currentCodeTheme.value}
     {@html sanitizeHtml(lo.contentHtml ?? "")}
   {/key}

--- a/src/lib/ui/learning-objects/content/QuizLo.svelte
+++ b/src/lib/ui/learning-objects/content/QuizLo.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { hideMainNavigator, currentCourse } from "$lib/runes.svelte";
+  import { parseQuizMarkdown } from "$lib/services/quiz/services/quiz-parser";
+  import QuizAsync from "$lib/ui/quiz/QuizAsync.svelte";
+  import type { Lo } from "@tutors/tutors-model-lib";
+  import type { Quiz } from "$lib/services/quiz";
+
+  interface Props {
+    lo: Lo;
+  }
+  let { lo }: Props = $props();
+
+  const parsed = $derived(lo.contentMd ? parseQuizMarkdown(lo.contentMd) : null);
+
+  const quiz = $derived.by((): Quiz | null => {
+    if (!parsed) return null;
+    return {
+      id: lo.route,
+      courseId: currentCourse.value?.courseId ?? "",
+      title: parsed.title,
+      questions: parsed.questions,
+      createdBy: "course",
+      source: "course",
+      timeLimit: parsed.timeLimit,
+      status: "published",
+      createdAt: ""
+    };
+  });
+
+  onMount(() => { hideMainNavigator.value = true; });
+  onDestroy(() => { hideMainNavigator.value = false; });
+</script>
+
+{#if quiz}
+  <QuizAsync {quiz} />
+{:else}
+  <div class="text-center py-12 text-error-500">
+    Invalid quiz format in this learning object
+  </div>
+{/if}

--- a/src/lib/ui/learning-objects/content/lab/Lab.svelte
+++ b/src/lib/ui/learning-objects/content/lab/Lab.svelte
@@ -7,6 +7,7 @@
   import { sanitizeHtml } from "$lib/utils/sanitize";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
+  import { quizify } from "$lib/services/quiz/services/quiz-action";
 
   interface Props {
     lab: LiveLab;
@@ -73,7 +74,7 @@
       </div>
     </div>
     <div class="min-h-screen flex-1">
-      <article class="prose dark:prose-invert prose-pre:overflow-x-auto 2xl:prose-pre:max-w-[120ch] max-w-[65ch] sm:mx-1 md:mx-4 2xl:max-w-[120ch]" use:mermaidify={lab.content} use:copyCode>
+      <article class="prose dark:prose-invert prose-pre:overflow-x-auto 2xl:prose-pre:max-w-[120ch] max-w-[65ch] sm:mx-1 md:mx-4 2xl:max-w-[120ch]" use:mermaidify={lab.content} use:copyCode use:quizify>
         {#key currentCodeTheme.value}
           <span id="lab-panel" class="mt-[-60px] block pt-[60px]">
             {@html sanitizeHtml(lab.content ?? "")}

--- a/src/lib/ui/navigators/MainNavigator.svelte
+++ b/src/lib/ui/navigators/MainNavigator.svelte
@@ -2,6 +2,7 @@
   import { AppBar } from "@skeletonlabs/skeleton-svelte";
   import CourseTitle from "./titles/CourseTitle.svelte";
   import SearchButton from "./buttons/SearchButton.svelte";
+  import QuizButton from "./buttons/QuizButton.svelte";
   import LayoutMenu from "./LayoutMenu.svelte";
   import LlmsIndicator from "./buttons/LlmsIndicator.svelte";
   import TutorsTimeIndicator from "./buttons/TutorsTimeIndicator.svelte";
@@ -53,6 +54,7 @@
         </div>
         <div class="flex items-center">
           {#if currentCourse?.value && !currentCourse?.value?.isPortfolio}
+            <QuizButton />
             <SearchButton />
           {/if}
         </div>

--- a/src/lib/ui/navigators/buttons/QuizButton.svelte
+++ b/src/lib/ui/navigators/buttons/QuizButton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse } from "$lib/runes.svelte";
+  import { getActiveSession, isQuizEnabled } from "$lib/services/quiz";
+  import Icon from "$lib/ui/components/Icon.svelte";
+
+  let hasActiveSession = $state(false);
+
+  const enabled = $derived(isQuizEnabled(currentCourse.value));
+
+  $effect(() => {
+    const courseId = currentCourse.value?.courseId;
+    if (courseId && enabled) {
+      getActiveSession(courseId).then((session) => {
+        hasActiveSession = session !== null;
+      });
+    } else {
+      hasActiveSession = false;
+    }
+  });
+
+  function navigateToQuiz() {
+    goto("/quiz/" + currentCourse?.value?.courseId);
+  }
+</script>
+
+{#if enabled}
+  <button onclick={navigateToQuiz}>
+    <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
+      <Icon type={hasActiveSession ? "quizLive" : "quiz"} tip="Course Quizzes" />
+      <span class="hidden lg:block">Quiz</span>
+      {#if hasActiveSession}
+        <span class="bg-error-500 h-2 w-2 rounded-full animate-pulse"></span>
+      {/if}
+    </div>
+  </button>
+{/if}

--- a/src/lib/ui/quiz/QuizAsync.svelte
+++ b/src/lib/ui/quiz/QuizAsync.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import { submitResponse, getAsyncResponses, getQuizUserId } from "$lib/services/quiz";
+  import type { Quiz, QuizResponse } from "$lib/services/quiz";
+  import QuizQuestion from "./QuizQuestion.svelte";
+  import QuizResults from "./QuizResults.svelte";
+
+  interface Props {
+    quiz: Quiz;
+  }
+
+  let { quiz }: Props = $props();
+
+  let currentIndex = $state(0);
+  let selectedAnswers = $state<Map<string, number>>(new Map());
+  let startTimes = $state<Map<string, number>>(new Map());
+  let submitted = $state(false);
+  let isSubmitting = $state(false);
+  let existingResponses = $state<QuizResponse[]>([]);
+  let isLoading = $state(true);
+
+  const studentId = $derived(getQuizUserId());
+  const currentQuestion = $derived(quiz.questions[currentIndex]);
+  const allAnswered = $derived(selectedAnswers.size === quiz.questions.length);
+  const alreadyTaken = $derived(existingResponses.length > 0);
+
+  $effect(() => {
+    if (studentId && quiz.id) {
+      getAsyncResponses(quiz.id, studentId).then((responses) => {
+        existingResponses = responses;
+        if (responses.length > 0) {
+          submitted = true;
+          for (const r of responses) {
+            selectedAnswers.set(r.questionId, r.selectedIndex);
+          }
+          selectedAnswers = new Map(selectedAnswers);
+        }
+        isLoading = false;
+      });
+    } else {
+      isLoading = false;
+    }
+  });
+
+  function handleSelect(questionId: string, index: number) {
+    if (submitted) return;
+    if (!startTimes.has(questionId)) {
+      startTimes.set(questionId, Date.now());
+      startTimes = new Map(startTimes);
+    }
+    selectedAnswers.set(questionId, index);
+    selectedAnswers = new Map(selectedAnswers);
+  }
+
+  function startQuestionTimer() {
+    const qid = currentQuestion.id;
+    if (!startTimes.has(qid)) {
+      startTimes.set(qid, Date.now());
+      startTimes = new Map(startTimes);
+    }
+  }
+
+  function goNext() {
+    if (currentIndex < quiz.questions.length - 1) {
+      currentIndex++;
+      startQuestionTimer();
+    }
+  }
+
+  function goPrev() {
+    if (currentIndex > 0) {
+      currentIndex--;
+    }
+  }
+
+  async function submitAll() {
+    if (!allAnswered || isSubmitting) return;
+    isSubmitting = true;
+
+    const responses: QuizResponse[] = [];
+    for (const question of quiz.questions) {
+      const selected = selectedAnswers.get(question.id);
+      if (selected === undefined) continue;
+
+      const startTime = startTimes.get(question.id) ?? Date.now();
+      const responseTimeMs = Date.now() - startTime;
+
+      const response = {
+        quizId: quiz.id,
+        sessionId: null,
+        questionId: question.id,
+        studentId,
+        selectedIndex: selected,
+        isCorrect: selected === question.correctIndex,
+        responseTimeMs
+      };
+
+      await submitResponse(response);
+      responses.push({ ...response, id: "", submittedAt: new Date().toISOString() });
+    }
+
+    existingResponses = responses;
+    submitted = true;
+    isSubmitting = false;
+  }
+
+  $effect(() => {
+    if (!submitted && !isLoading) {
+      startQuestionTimer();
+    }
+  });
+</script>
+
+{#if isLoading}
+  <div class="text-center py-12 text-surface-500">Loading...</div>
+{:else if submitted}
+  <div class="mx-4 mt-4 max-w-3xl mx-auto">
+    <h2 class="text-xl font-bold mb-4">{quiz.title} - Results</h2>
+    {#if alreadyTaken && existingResponses.length > 0}
+      <QuizResults {quiz} responses={existingResponses} {studentId} />
+    {:else}
+      <QuizResults {quiz} responses={existingResponses} {studentId} />
+    {/if}
+  </div>
+{:else}
+  <div class="mx-4 mt-4 max-w-3xl mx-auto space-y-6">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">{quiz.title}</h2>
+      <span class="text-sm text-surface-500">
+        Question {currentIndex + 1} of {quiz.questions.length}
+      </span>
+    </div>
+
+    <div class="w-full bg-surface-200 dark:bg-surface-700 rounded-full h-2">
+      <div
+        class="bg-primary-500 h-2 rounded-full transition-all"
+        style="width: {((currentIndex + 1) / quiz.questions.length) * 100}%"
+      ></div>
+    </div>
+
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-6">
+      <QuizQuestion
+        questionIndex={currentIndex}
+        text={currentQuestion.text}
+        options={currentQuestion.options}
+        questionType={currentQuestion.type}
+        selectedIndex={selectedAnswers.get(currentQuestion.id) ?? null}
+        disabled={false}
+        showCorrect={false}
+        onselect={(index) => handleSelect(currentQuestion.id, index)}
+      />
+    </div>
+
+    <div class="flex items-center justify-between">
+      <button
+        class="px-4 py-2 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800 disabled:opacity-50"
+        onclick={goPrev}
+        disabled={currentIndex === 0}
+      >
+        Previous
+      </button>
+
+      <div class="flex gap-2">
+        {#each quiz.questions as _, i}
+          <button
+            class="w-8 h-8 rounded-full text-xs font-medium transition-colors
+              {i === currentIndex
+                ? 'bg-primary-500 text-white'
+                : selectedAnswers.has(quiz.questions[i].id)
+                  ? 'bg-primary-200 dark:bg-primary-800 text-primary-700 dark:text-primary-300'
+                  : 'bg-surface-200 dark:bg-surface-700 text-surface-500'}"
+            onclick={() => { currentIndex = i; startQuestionTimer(); }}
+          >
+            {i + 1}
+          </button>
+        {/each}
+      </div>
+
+      {#if currentIndex === quiz.questions.length - 1}
+        <button
+          class="px-4 py-2 rounded-lg text-sm preset-filled-primary-500 disabled:opacity-50"
+          onclick={submitAll}
+          disabled={!allAnswered || isSubmitting}
+        >
+          {isSubmitting ? "Submitting..." : "Submit All"}
+        </button>
+      {:else}
+        <button
+          class="px-4 py-2 rounded-lg text-sm preset-filled-primary-500"
+          onclick={goNext}
+        >
+          Next
+        </button>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/src/lib/ui/quiz/QuizCreator.svelte
+++ b/src/lib/ui/quiz/QuizCreator.svelte
@@ -1,0 +1,283 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse } from "$lib/runes.svelte";
+  import { createQuiz, updateQuiz, getQuizUserId } from "$lib/services/quiz";
+  import type { Quiz, QuizQuestion, QuestionType } from "$lib/services/quiz";
+
+  interface Props {
+    existingQuiz?: Quiz;
+  }
+
+  let { existingQuiz }: Props = $props();
+
+  let title = $state(existingQuiz?.title ?? "");
+  let timeLimit = $state<string>(existingQuiz?.timeLimit?.toString() ?? "");
+  let questions = $state<QuizQuestion[]>(
+    existingQuiz?.questions ?? [
+      { id: "q1", type: "multiple-choice", text: "", options: ["", ""], correctIndex: 0 }
+    ]
+  );
+  let isSaving = $state(false);
+  let error = $state("");
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+
+  function addQuestion() {
+    const id = `q${questions.length + 1}`;
+    questions = [
+      ...questions,
+      { id, type: "multiple-choice", text: "", options: ["", ""], correctIndex: 0 }
+    ];
+  }
+
+  function removeQuestion(index: number) {
+    if (questions.length <= 1) return;
+    questions = questions.filter((_, i) => i !== index);
+  }
+
+  function setQuestionType(index: number, type: QuestionType) {
+    const q = { ...questions[index], type };
+    if (type === "true-false") {
+      q.options = ["True", "False"];
+      q.correctIndex = 0;
+    } else if (questions[index].type === "true-false") {
+      q.options = ["", ""];
+      q.correctIndex = 0;
+    }
+    questions = questions.map((existing, i) => (i === index ? q : existing));
+  }
+
+  function addOption(qIndex: number) {
+    if (questions[qIndex].options.length >= 6) return;
+    const q = { ...questions[qIndex], options: [...questions[qIndex].options, ""] };
+    questions = questions.map((existing, i) => (i === qIndex ? q : existing));
+  }
+
+  function removeOption(qIndex: number, oIndex: number) {
+    if (questions[qIndex].options.length <= 2) return;
+    const q = { ...questions[qIndex] };
+    q.options = q.options.filter((_, i) => i !== oIndex);
+    if (q.correctIndex >= q.options.length) {
+      q.correctIndex = 0;
+    }
+    questions = questions.map((existing, i) => (i === qIndex ? q : existing));
+  }
+
+  function updateOptionText(qIndex: number, oIndex: number, value: string) {
+    const q = { ...questions[qIndex] };
+    q.options = q.options.map((o, i) => (i === oIndex ? value : o));
+    questions = questions.map((existing, i) => (i === qIndex ? q : existing));
+  }
+
+  function updateQuestionText(qIndex: number, value: string) {
+    questions = questions.map((q, i) => (i === qIndex ? { ...q, text: value } : q));
+  }
+
+  function setCorrectAnswer(qIndex: number, oIndex: number) {
+    questions = questions.map((q, i) => (i === qIndex ? { ...q, correctIndex: oIndex } : q));
+  }
+
+  function validate(): string | null {
+    if (!title.trim()) return "Quiz title is required";
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i];
+      if (!q.text.trim()) return `Question ${i + 1}: text is required`;
+      if (q.type === "multiple-choice") {
+        const filledOptions = q.options.filter((o) => o.trim());
+        if (filledOptions.length < 2) return `Question ${i + 1}: at least 2 options are required`;
+      }
+    }
+    return null;
+  }
+
+  async function save(publishImmediately: boolean) {
+    const validationError = validate();
+    if (validationError) {
+      error = validationError;
+      return;
+    }
+    error = "";
+    isSaving = true;
+
+    const cleanedQuestions = questions.map((q, i) => ({
+      ...q,
+      id: q.id || `q${i + 1}`,
+      options: q.type === "true-false" ? ["True", "False"] : q.options.filter((o) => o.trim())
+    }));
+
+    const timeLimitNum = timeLimit ? parseInt(timeLimit, 10) : null;
+
+    if (existingQuiz) {
+      await updateQuiz(existingQuiz.id, {
+        title: title.trim(),
+        questions: cleanedQuestions,
+        timeLimit: timeLimitNum,
+        status: publishImmediately ? "published" : existingQuiz.status
+      });
+    } else {
+      await createQuiz({
+        courseId,
+        title: title.trim(),
+        questions: cleanedQuestions,
+        createdBy: getQuizUserId(),
+        source: "dynamic",
+        timeLimit: timeLimitNum,
+        status: publishImmediately ? "published" : "draft"
+      });
+    }
+
+    isSaving = false;
+    goto(`/quiz/${courseId}`);
+  }
+</script>
+
+<div class="mx-4 mt-4 max-w-3xl mx-auto space-y-6">
+  <h2 class="text-xl font-bold">{existingQuiz ? "Edit Quiz" : "Create Quiz"}</h2>
+
+  {#if error}
+    <div class="bg-error-500/10 border-error-500 border-[1px] rounded-lg p-3 text-error-500 text-sm">
+      {error}
+    </div>
+  {/if}
+
+  <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 space-y-4">
+    <div>
+      <label for="quiz-title" class="block text-sm font-medium mb-1">Quiz Title</label>
+      <input
+        id="quiz-title"
+        type="text"
+        bind:value={title}
+        placeholder="e.g., Week 3 Review"
+        class="w-full rounded-lg border-[1px] border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-800 p-2.5 text-sm"
+      />
+    </div>
+    <div>
+      <label for="time-limit" class="block text-sm font-medium mb-1">Time Limit per Question (seconds, optional)</label>
+      <input
+        id="time-limit"
+        type="number"
+        bind:value={timeLimit}
+        placeholder="e.g., 30"
+        min="5"
+        max="300"
+        class="w-48 rounded-lg border-[1px] border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-800 p-2.5 text-sm"
+      />
+    </div>
+  </div>
+
+  {#each questions as question, qi}
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 space-y-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <span class="bg-primary-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold">
+            {qi + 1}
+          </span>
+          <select
+            class="rounded-lg border-[1px] border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-800 p-1.5 text-sm"
+            value={question.type}
+            onchange={(e) => setQuestionType(qi, (e.target as HTMLSelectElement).value as QuestionType)}
+          >
+            <option value="multiple-choice">Multiple Choice</option>
+            <option value="true-false">True / False</option>
+          </select>
+        </div>
+        {#if questions.length > 1}
+          <button
+            class="text-sm text-error-500 hover:text-error-700"
+            onclick={() => removeQuestion(qi)}
+          >
+            Remove
+          </button>
+        {/if}
+      </div>
+
+      <div>
+        <label for="q-{qi}-text" class="block text-sm font-medium mb-1">Question</label>
+        <textarea
+          id="q-{qi}-text"
+          value={question.text}
+          oninput={(e) => updateQuestionText(qi, (e.target as HTMLTextAreaElement).value)}
+          placeholder="Enter your question..."
+          rows="2"
+          class="w-full rounded-lg border-[1px] border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-800 p-2.5 text-sm resize-y"
+        ></textarea>
+      </div>
+
+      <div class="space-y-2">
+        <span class="block text-sm font-medium">Options (select the correct answer)</span>
+        {#each question.options as option, oi}
+          <div class="flex items-center gap-2">
+            <button
+              class="w-7 h-7 rounded-full border-[2px] flex items-center justify-center text-xs font-medium shrink-0 transition-colors
+                {question.correctIndex === oi
+                  ? 'border-success-500 bg-success-500 text-white'
+                  : 'border-surface-400 text-surface-500 hover:border-success-400'}"
+              onclick={() => setCorrectAnswer(qi, oi)}
+              title="Mark as correct answer"
+            >
+              {String.fromCharCode(65 + oi)}
+            </button>
+            {#if question.type === "true-false"}
+              <span class="text-sm flex-1">{option}</span>
+            {:else}
+              <input
+                type="text"
+                value={option}
+                oninput={(e) => updateOptionText(qi, oi, (e.target as HTMLInputElement).value)}
+                placeholder="Option {String.fromCharCode(65 + oi)}"
+                class="flex-1 rounded-lg border-[1px] border-surface-300 dark:border-surface-600 bg-surface-50 dark:bg-surface-800 p-2 text-sm"
+              />
+              {#if question.options.length > 2}
+                <button
+                  class="text-sm text-surface-400 hover:text-error-500"
+                  onclick={() => removeOption(qi, oi)}
+                >
+                  &times;
+                </button>
+              {/if}
+            {/if}
+          </div>
+        {/each}
+        {#if question.type === "multiple-choice" && question.options.length < 6}
+          <button
+            class="text-sm text-primary-500 hover:text-primary-700 ml-9"
+            onclick={() => addOption(qi)}
+          >
+            + Add Option
+          </button>
+        {/if}
+      </div>
+    </div>
+  {/each}
+
+  <button
+    class="w-full border-[1px] border-dashed border-surface-400 dark:border-surface-600 rounded-xl p-4 text-surface-500 hover:text-primary-500 hover:border-primary-500 transition-colors"
+    onclick={addQuestion}
+  >
+    + Add Question
+  </button>
+
+  <div class="flex gap-3 justify-end pb-8">
+    <button
+      class="px-4 py-2 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+      onclick={() => goto(`/quiz/${courseId}`)}
+      disabled={isSaving}
+    >
+      Cancel
+    </button>
+    <button
+      class="px-4 py-2 rounded-lg text-sm border-[1px] border-primary-500 text-primary-500 hover:bg-primary-500/10"
+      onclick={() => save(false)}
+      disabled={isSaving}
+    >
+      {isSaving ? "Saving..." : "Save as Draft"}
+    </button>
+    <button
+      class="px-4 py-2 rounded-lg text-sm preset-filled-primary-500"
+      onclick={() => save(true)}
+      disabled={isSaving}
+    >
+      {isSaving ? "Saving..." : "Save & Publish"}
+    </button>
+  </div>
+</div>

--- a/src/lib/ui/quiz/QuizDashboard.svelte
+++ b/src/lib/ui/quiz/QuizDashboard.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse } from "$lib/runes.svelte";
+  import {
+    getQuizzesByCourse,
+    getActiveSession,
+    isLecturer,
+    publishQuiz,
+    archiveQuiz,
+    createSession,
+    getQuizUserId,
+    getQuizUserName,
+    seedRemoteQuiz
+  } from "$lib/services/quiz";
+  import type { Quiz, QuizSession } from "$lib/services/quiz";
+  import { presenceService } from "$lib/services/community";
+  import { toaster } from "$lib/stores/toaster";
+  import { filterByType, flattenLos } from "@tutors/tutors-model-lib";
+  import { parseQuizMarkdown } from "$lib/services/quiz/services/quiz-parser";
+
+  let dynamicQuizzes = $state<Quiz[]>([]);
+  let activeSession = $state<QuizSession | null>(null);
+  let isLoading = $state(true);
+
+  const lecturer = $derived(isLecturer(currentCourse.value, getQuizUserId()));
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+
+  const courseQuizzes = $derived.by((): Quiz[] => {
+    const course = currentCourse.value;
+    if (!course?.los) return [];
+    const quizLos = filterByType(flattenLos(course.los), "quiz");
+    return quizLos
+      .map((lo) => {
+        if (!lo.contentMd) return null;
+        const parsed = parseQuizMarkdown(lo.contentMd);
+        if (!parsed) return null;
+        return {
+          id: lo.id,
+          courseId: course.courseId ?? "",
+          title: parsed.title,
+          questions: parsed.questions,
+          createdBy: "course",
+          source: "course" as const,
+          timeLimit: parsed.timeLimit,
+          status: "published" as const,
+          createdAt: ""
+        };
+      })
+      .filter((q): q is Quiz => q !== null);
+  });
+
+  $effect(() => {
+    if (!courseId) return;
+    isLoading = true;
+    Promise.all([
+      getQuizzesByCourse(courseId),
+      getActiveSession(courseId)
+    ]).then(([q, s]) => {
+      dynamicQuizzes = q;
+      activeSession = s;
+    }).finally(() => {
+      isLoading = false;
+    });
+  });
+
+  const quizzes = $derived([...courseQuizzes, ...dynamicQuizzes]);
+  const publishedQuizzes = $derived(quizzes.filter((q) => q.status === "published"));
+  const draftQuizzes = $derived(quizzes.filter((q) => q.status === "draft"));
+  const archivedQuizzes = $derived(quizzes.filter((q) => q.status === "archived"));
+
+  async function handlePublish(quiz: Quiz) {
+    await publishQuiz(quiz.id);
+    dynamicQuizzes = dynamicQuizzes.map((q) => (q.id === quiz.id ? { ...q, status: "published" as const } : q));
+  }
+
+  async function handleArchive(quiz: Quiz) {
+    await archiveQuiz(quiz.id);
+    dynamicQuizzes = dynamicQuizzes.map((q) => (q.id === quiz.id ? { ...q, status: "archived" as const } : q));
+  }
+
+  async function handleStartSession(quiz: Quiz) {
+    const plainQuiz = JSON.parse(JSON.stringify(quiz)) as Quiz;
+    seedRemoteQuiz(plainQuiz);
+    const session = await createSession(plainQuiz.id, courseId, getQuizUserId());
+    if (session) {
+      const notification = {
+        type: "quiz:live-started",
+        sessionId: session.id,
+        quizTitle: quiz.title,
+        courseId,
+        lecturerName: getQuizUserName(),
+        quiz,
+        session
+      };
+      if (presenceService.listeningTo !== "") {
+        try {
+          presenceService.partyKitCourse.send(JSON.stringify(notification));
+        } catch { /* PartyKit unavailable */ }
+      }
+      try {
+        const plain = JSON.parse(JSON.stringify(notification));
+        const bc = new BroadcastChannel("tutors-quiz-notifications");
+        bc.postMessage(plain);
+      } catch { /* BroadcastChannel unavailable */ }
+      toaster.create({
+        title: `Live Quiz Started`,
+        description: quiz.title,
+        type: "success"
+      });
+      sessionStorage.setItem("quizHostSession", session.id);
+      goto(`/quiz/${courseId}/live/${session.id}`);
+    }
+  }
+</script>
+
+<div class="mx-4 mt-4 space-y-6">
+  {#if activeSession}
+    <button
+      class="w-full bg-error-500/10 border-error-500 border-[1px] rounded-xl p-6 text-center cursor-pointer hover:bg-error-500/20 transition-colors"
+      onclick={() => goto(`/quiz/${courseId}/live/${activeSession!.id}`)}
+    >
+      <div class="flex items-center justify-center gap-3">
+        <span class="bg-error-500 h-3 w-3 rounded-full animate-pulse"></span>
+        <span class="text-xl font-bold text-error-500">Live Quiz in Progress</span>
+      </div>
+      <p class="text-sm text-surface-500 mt-2">Click to {lecturer ? "manage" : "join"} the live session</p>
+    </button>
+  {/if}
+
+  {#if lecturer}
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">Quiz Management</h2>
+      <button
+        class="preset-filled-primary-500 px-4 py-2 rounded-lg text-sm font-medium"
+        onclick={() => goto(`/quiz/${courseId}/create`)}
+      >
+        Create Quiz
+      </button>
+    </div>
+  {/if}
+
+  {#if isLoading}
+    <div class="text-center py-12 text-surface-500">Loading quizzes...</div>
+  {:else if publishedQuizzes.length === 0 && (!lecturer || draftQuizzes.length === 0)}
+    <div class="text-center py-12">
+      <p class="text-surface-500 text-lg">No quizzes available yet</p>
+      {#if lecturer}
+        <p class="text-surface-400 text-sm mt-2">Create your first quiz to get started</p>
+      {/if}
+    </div>
+  {:else}
+    {#if lecturer && draftQuizzes.length > 0}
+      <div>
+        <h3 class="text-lg font-semibold mb-3 text-surface-500">Drafts</h3>
+        <div class="grid gap-3">
+          {#each draftQuizzes as quiz}
+            <div class="border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <h4 class="font-medium">{quiz.title}</h4>
+                  <p class="text-sm text-surface-500">
+                    {quiz.questions.length} question{quiz.questions.length !== 1 ? "s" : ""}
+                    {#if quiz.timeLimit}
+                      &middot; {quiz.timeLimit}s per question
+                    {/if}
+                  </p>
+                </div>
+                <div class="flex gap-2">
+                  <button
+                    class="px-3 py-1.5 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+                    onclick={() => goto(`/quiz/${courseId}/${quiz.id}`)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    class="px-3 py-1.5 rounded-lg text-sm preset-filled-primary-500"
+                    onclick={() => handlePublish(quiz)}
+                  >
+                    Publish
+                  </button>
+                </div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if publishedQuizzes.length > 0}
+      <div>
+        {#if lecturer}
+          <h3 class="text-lg font-semibold mb-3">Published Quizzes</h3>
+        {/if}
+        <div class="grid gap-3">
+          {#each publishedQuizzes as quiz}
+            <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4">
+              <div class="flex items-center justify-between">
+                <div>
+                  <h4 class="font-medium">{quiz.title}</h4>
+                  <p class="text-sm text-surface-500">
+                    {quiz.questions.length} question{quiz.questions.length !== 1 ? "s" : ""}
+                    {#if quiz.timeLimit}
+                      &middot; {quiz.timeLimit}s per question
+                    {/if}
+                  </p>
+                </div>
+                <div class="flex gap-2">
+                  {#if lecturer}
+                    <button
+                      class="px-3 py-1.5 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+                      onclick={() => goto(`/quiz/${courseId}/${quiz.id}/results`)}
+                    >
+                      Results
+                    </button>
+                    <button
+                      class="px-3 py-1.5 rounded-lg text-sm preset-filled-primary-500"
+                      onclick={() => handleStartSession(quiz)}
+                      disabled={activeSession !== null}
+                    >
+                      Start Live
+                    </button>
+                    <button
+                      class="px-3 py-1.5 rounded-lg text-sm text-surface-500 hover:text-error-500"
+                      onclick={() => handleArchive(quiz)}
+                    >
+                      Archive
+                    </button>
+                  {:else}
+                    <button
+                      class="px-3 py-1.5 rounded-lg text-sm preset-filled-primary-500"
+                      onclick={() => goto(`/quiz/${courseId}/${quiz.id}`)}
+                    >
+                      Take Quiz
+                    </button>
+                  {/if}
+                </div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if lecturer && archivedQuizzes.length > 0}
+      <details class="mt-4">
+        <summary class="text-sm text-surface-500 cursor-pointer hover:text-surface-700">
+          Archived ({archivedQuizzes.length})
+        </summary>
+        <div class="grid gap-3 mt-3">
+          {#each archivedQuizzes as quiz}
+            <div class="border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 opacity-60">
+              <div class="flex items-center justify-between">
+                <div>
+                  <h4 class="font-medium">{quiz.title}</h4>
+                  <p class="text-sm text-surface-500">{quiz.questions.length} questions</p>
+                </div>
+                <button
+                  class="px-3 py-1.5 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+                  onclick={() => goto(`/quiz/${courseId}/${quiz.id}/results`)}
+                >
+                  Results
+                </button>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </details>
+    {/if}
+  {/if}
+</div>

--- a/src/lib/ui/quiz/QuizLiveHost.svelte
+++ b/src/lib/ui/quiz/QuizLiveHost.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { goto } from "$app/navigation";
+  import { currentCourse } from "$lib/runes.svelte";
+  import {
+    quizSessionState,
+    getSessionById,
+    getQuizById,
+    updateSessionStatus,
+    endSession,
+    getResponsesForQuestion,
+    computeQuestionAnalytics
+  } from "$lib/services/quiz";
+  import type { Quiz, QuizSession, QuizResponse } from "$lib/services/quiz";
+  import QuizQuestion from "./QuizQuestion.svelte";
+  import QuizResultsChart from "./QuizResultsChart.svelte";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+
+  let session = $state<QuizSession | null>(null);
+  let quiz = $state<Quiz | null>(null);
+  let isLoading = $state(true);
+  let questionIndex = $state(-1);
+  let revealed = $state(false);
+  let currentDistribution = $state<number[]>([]);
+  let questionResponses = $state<QuizResponse[]>([]);
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+  const participants = $derived(quizSessionState.participantCount.value);
+  const answers = $derived(quizSessionState.answers.value);
+  const answerCount = $derived(answers.length);
+  const currentQ = $derived(quiz?.questions[questionIndex] ?? null);
+  const isLastQuestion = $derived(quiz ? questionIndex >= quiz.questions.length - 1 : false);
+  const quizStarted = $derived(questionIndex >= 0);
+
+  $effect(() => {
+    loadSession();
+  });
+
+  async function loadSession() {
+    isLoading = true;
+    session = await getSessionById(sessionId);
+    if (session) {
+      quiz = await getQuizById(session.quizId);
+      quizSessionState.connect(courseId, sessionId);
+      questionIndex = session.currentQuestion > 0 ? session.currentQuestion : -1;
+    }
+    isLoading = false;
+  }
+
+  function pushNextQuestion() {
+    if (!quiz) return;
+    const nextIndex = questionIndex + 1;
+    if (nextIndex >= quiz.questions.length) return;
+
+    questionIndex = nextIndex;
+    revealed = false;
+    currentDistribution = [];
+    questionResponses = [];
+
+    const q = quiz.questions[nextIndex];
+    quizSessionState.pushQuestion(
+      nextIndex,
+      q.text,
+      q.options,
+      q.type,
+      quiz.timeLimit
+    );
+    updateSessionStatus(sessionId, "active", nextIndex);
+  }
+
+  async function revealResults() {
+    if (!quiz || !currentQ) return;
+
+    questionResponses = await getResponsesForQuestion(sessionId, currentQ.id);
+    const dist = new Array(currentQ.options.length).fill(0);
+    for (const r of questionResponses) {
+      if (r.selectedIndex >= 0 && r.selectedIndex < dist.length) {
+        dist[r.selectedIndex]++;
+      }
+    }
+    currentDistribution = dist;
+    revealed = true;
+
+    quizSessionState.revealAnswer(questionIndex, currentQ.correctIndex, dist);
+    updateSessionStatus(sessionId, "reviewing", questionIndex);
+  }
+
+  async function handleEndQuiz() {
+    quizSessionState.endQuiz();
+    await endSession(sessionId);
+    await new Promise((r) => setTimeout(r, 200));
+    if (quiz) {
+      goto(`/quiz/${courseId}/${quiz.id}/results`);
+    } else {
+      goto(`/quiz/${courseId}`);
+    }
+  }
+
+  const correctCount = $derived(
+    revealed ? questionResponses.filter((r) => r.isCorrect).length : 0
+  );
+  const avgTime = $derived(
+    revealed && questionResponses.length > 0
+      ? Math.round(questionResponses.reduce((a, r) => a + r.responseTimeMs, 0) / questionResponses.length / 100) / 10
+      : 0
+  );
+
+  onDestroy(() => {
+    quizSessionState.disconnect();
+  });
+</script>
+
+{#if isLoading}
+  <div class="text-center py-12 text-surface-500">Loading session...</div>
+{:else if !quiz}
+  <div class="text-center py-12 text-surface-500">Session not found</div>
+{:else}
+  <div class="mx-4 mt-4 max-w-4xl mx-auto space-y-6">
+    <div class="flex items-center justify-between">
+      <h2 class="text-xl font-bold">{quiz.title}</h2>
+      <div class="flex items-center gap-4">
+        <div class="flex items-center gap-2 text-sm text-surface-500">
+          <span class="bg-success-500 h-2 w-2 rounded-full"></span>
+          {participants} participant{participants !== 1 ? "s" : ""}
+        </div>
+        <button
+          class="px-3 py-1.5 rounded-lg text-sm text-error-500 border-[1px] border-error-500 hover:bg-error-500/10"
+          onclick={handleEndQuiz}
+        >
+          End Quiz
+        </button>
+      </div>
+    </div>
+
+    {#if !quizStarted}
+      <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-8 text-center space-y-4">
+        <div class="text-6xl font-bold text-primary-500">{participants}</div>
+        <p class="text-surface-500">participant{participants !== 1 ? "s" : ""} connected</p>
+        <p class="text-sm text-surface-400">Waiting for students to join...</p>
+        <button
+          class="px-6 py-3 rounded-lg text-lg preset-filled-primary-500 mt-4"
+          onclick={pushNextQuestion}
+        >
+          Start Quiz
+        </button>
+      </div>
+    {:else if currentQ}
+      <div class="grid grid-cols-3 gap-4">
+        <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+          <div class="text-2xl font-bold">{answerCount}</div>
+          <div class="text-sm text-surface-500">Answers</div>
+        </div>
+        <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+          <div class="text-2xl font-bold">{questionIndex + 1}/{quiz.questions.length}</div>
+          <div class="text-sm text-surface-500">Question</div>
+        </div>
+        {#if revealed}
+          <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+            <div class="text-2xl font-bold {correctCount > answerCount / 2 ? 'text-success-500' : 'text-error-500'}">
+              {correctCount}/{answerCount}
+            </div>
+            <div class="text-sm text-surface-500">Correct</div>
+          </div>
+        {:else}
+          <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+            <div class="text-2xl font-bold text-surface-400">--</div>
+            <div class="text-sm text-surface-500">Correct</div>
+          </div>
+        {/if}
+      </div>
+
+      <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-6">
+        {#if revealed}
+          <QuizQuestion
+            {questionIndex}
+            text={currentQ.text}
+            options={currentQ.options}
+            questionType={currentQ.type}
+            selectedIndex={null}
+            disabled={true}
+            showCorrect={true}
+            correctIndex={currentQ.correctIndex}
+            distribution={currentDistribution}
+          />
+          {#if avgTime > 0}
+            <div class="mt-4 text-sm text-surface-500 text-center">
+              Average response time: {avgTime}s
+            </div>
+          {/if}
+        {:else}
+          <QuizQuestion
+            {questionIndex}
+            text={currentQ.text}
+            options={currentQ.options}
+            questionType={currentQ.type}
+            selectedIndex={null}
+            disabled={true}
+            showCorrect={false}
+          />
+        {/if}
+      </div>
+
+      <div class="flex justify-center gap-4">
+        {#if !revealed}
+          <button
+            class="px-6 py-3 rounded-lg text-sm preset-filled-primary-500"
+            onclick={revealResults}
+          >
+            Reveal Answer
+          </button>
+        {:else if !isLastQuestion}
+          <button
+            class="px-6 py-3 rounded-lg text-sm preset-filled-primary-500"
+            onclick={pushNextQuestion}
+          >
+            Next Question
+          </button>
+        {:else}
+          <button
+            class="px-6 py-3 rounded-lg text-sm preset-filled-primary-500"
+            onclick={handleEndQuiz}
+          >
+            Finish Quiz
+          </button>
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/ui/quiz/QuizLiveStudent.svelte
+++ b/src/lib/ui/quiz/QuizLiveStudent.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { goto } from "$app/navigation";
+  import { currentCourse } from "$lib/runes.svelte";
+  import { quizSessionState, getSessionById, getQuizById, submitResponse, getQuizUserId, getQuizUserName, getQuizUserAvatar } from "$lib/services/quiz";
+  import type { Quiz, QuizSession } from "$lib/services/quiz";
+  import QuizQuestion from "./QuizQuestion.svelte";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+
+  let session = $state<QuizSession | null>(null);
+  let quiz = $state<Quiz | null>(null);
+  let isLoading = $state(true);
+  let answered = $state(false);
+  let selectedAnswer = $state<number | null>(null);
+  let questionStartTime = $state(0);
+  let responseTimeMs = $state(0);
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+  const studentId = $derived(getQuizUserId());
+  const studentName = $derived(getQuizUserName());
+  const avatar = $derived(getQuizUserAvatar());
+
+  const currentQuestion = $derived(quizSessionState.currentQuestion.value);
+  const revealData = $derived(quizSessionState.revealData.value);
+  const sessionEnded = $derived(quizSessionState.sessionEnded.value);
+  const participants = $derived(quizSessionState.participantCount.value);
+
+  $effect(() => {
+    loadSession();
+  });
+
+  async function loadSession() {
+    isLoading = true;
+    session = await getSessionById(sessionId);
+    if (session) {
+      quiz = await getQuizById(session.quizId);
+      quizSessionState.connect(courseId, sessionId);
+      quizSessionState.joinSession(studentId, studentName, avatar);
+    }
+    isLoading = false;
+  }
+
+  $effect(() => {
+    if (currentQuestion) {
+      answered = false;
+      selectedAnswer = null;
+      questionStartTime = Date.now();
+      responseTimeMs = 0;
+    }
+  });
+
+  async function handleSelect(index: number) {
+    if (answered || !currentQuestion || !quiz) return;
+
+    selectedAnswer = index;
+    answered = true;
+    responseTimeMs = Date.now() - questionStartTime;
+
+    quizSessionState.submitAnswer(studentId, currentQuestion.questionIndex, index, responseTimeMs);
+
+    const question = quiz.questions[currentQuestion.questionIndex];
+    if (question) {
+      await submitResponse({
+        quizId: quiz.id,
+        sessionId,
+        questionId: question.id,
+        studentId,
+        selectedIndex: index,
+        isCorrect: index === question.correctIndex,
+        responseTimeMs
+      });
+    }
+  }
+
+  onDestroy(() => {
+    quizSessionState.disconnect();
+  });
+</script>
+
+{#if isLoading}
+  <div class="text-center py-12 text-surface-500">Joining session...</div>
+{:else if sessionEnded}
+  <div class="mx-4 mt-4 max-w-3xl mx-auto text-center space-y-4">
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-8">
+      <h2 class="text-2xl font-bold mb-2">Quiz Complete!</h2>
+      <p class="text-surface-500">The quiz session has ended</p>
+      {#if quiz}
+        <button
+          class="mt-4 px-4 py-2 rounded-lg text-sm preset-filled-primary-500"
+          onclick={() => goto(`/quiz/${courseId}/${quiz!.id}/results`)}
+        >
+          View Your Results
+        </button>
+      {/if}
+    </div>
+  </div>
+{:else if !currentQuestion}
+  <div class="mx-4 mt-4 max-w-3xl mx-auto text-center space-y-4">
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-8">
+      <div class="animate-pulse text-4xl mb-4">&#9203;</div>
+      <h2 class="text-xl font-bold mb-2">Waiting for the quiz to start...</h2>
+      <p class="text-surface-500">{participants} participant{participants !== 1 ? "s" : ""} connected</p>
+      {#if quiz}
+        <p class="text-sm text-surface-400 mt-2">{quiz.title}</p>
+      {/if}
+    </div>
+  </div>
+{:else}
+  <div class="mx-4 mt-4 max-w-3xl mx-auto space-y-6">
+    <div class="flex items-center justify-between">
+      <span class="text-sm text-surface-500">
+        Question {currentQuestion.questionIndex + 1}
+        {#if quiz}
+          of {quiz.questions.length}
+        {/if}
+      </span>
+      {#if answered && !revealData}
+        <span class="text-sm text-success-500 font-medium">Answer submitted ({(responseTimeMs / 1000).toFixed(1)}s)</span>
+      {/if}
+    </div>
+
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-6">
+      <QuizQuestion
+        questionIndex={currentQuestion.questionIndex}
+        text={currentQuestion.text}
+        options={currentQuestion.options}
+        questionType={currentQuestion.questionType}
+        selectedIndex={selectedAnswer}
+        disabled={answered}
+        showCorrect={revealData !== null}
+        correctIndex={revealData?.correctIndex}
+        distribution={revealData?.distribution}
+        onselect={handleSelect}
+      />
+    </div>
+
+    {#if revealData && selectedAnswer !== null}
+      <div class="text-center">
+        {#if selectedAnswer === revealData.correctIndex}
+          <span class="text-2xl font-bold text-success-500">Correct!</span>
+        {:else}
+          <span class="text-2xl font-bold text-error-500">Incorrect</span>
+        {/if}
+        <p class="text-sm text-surface-500 mt-1">
+          Response time: {(responseTimeMs / 1000).toFixed(1)}s
+        </p>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/ui/quiz/QuizNotificationListener.svelte
+++ b/src/lib/ui/quiz/QuizNotificationListener.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { presenceService } from "$lib/services/community";
+  import { toaster } from "$lib/stores/toaster";
+  import { seedRemoteSession, seedRemoteQuiz } from "$lib/services/quiz";
+  import type { QuizLiveStartedNotification } from "$lib/services/quiz/types";
+
+  let broadcastChannel: BroadcastChannel | null = null;
+
+  function handleQuizStarted(notification: QuizLiveStartedNotification) {
+    if (notification.session) seedRemoteSession(notification.session);
+    if (notification.quiz) seedRemoteQuiz(notification.quiz);
+
+    toaster.create({
+      title: `Live Quiz: ${notification.quizTitle}`,
+      description: `${notification.lecturerName} started a live quiz`,
+      type: "info",
+      duration: 15000,
+      meta: {
+        actionUrl: `/quiz/${notification.courseId}/live/${notification.sessionId}`,
+        actionLabel: "Join Quiz"
+      }
+    });
+  }
+
+  onMount(() => {
+    presenceService.onQuizStarted = handleQuizStarted;
+
+    try {
+      broadcastChannel = new BroadcastChannel("tutors-quiz-notifications");
+      broadcastChannel.onmessage = (event) => {
+        if (event.data?.type === "quiz:live-started") {
+          handleQuizStarted(event.data);
+        }
+      };
+    } catch { /* BroadcastChannel unavailable */ }
+  });
+
+  onDestroy(() => {
+    if (presenceService.onQuizStarted === handleQuizStarted) {
+      presenceService.onQuizStarted = undefined;
+    }
+    broadcastChannel?.close();
+    broadcastChannel = null;
+  });
+</script>

--- a/src/lib/ui/quiz/QuizQuestion.svelte
+++ b/src/lib/ui/quiz/QuizQuestion.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import type { QuestionType } from "$lib/services/quiz";
+
+  interface Props {
+    questionIndex: number;
+    text: string;
+    options: string[];
+    questionType: QuestionType;
+    selectedIndex: number | null;
+    disabled: boolean;
+    showCorrect: boolean;
+    correctIndex?: number;
+    distribution?: number[];
+    onselect?: (index: number) => void;
+  }
+
+  let {
+    questionIndex,
+    text,
+    options,
+    questionType,
+    selectedIndex,
+    disabled,
+    showCorrect,
+    correctIndex,
+    distribution,
+    onselect
+  }: Props = $props();
+
+  function handleSelect(index: number) {
+    if (!disabled && onselect) {
+      onselect(index);
+    }
+  }
+
+  function optionClass(index: number): string {
+    const base = "w-full text-left p-4 rounded-lg border-[1px] transition-all";
+    if (showCorrect && correctIndex !== undefined) {
+      if (index === correctIndex) {
+        return `${base} border-success-500 bg-success-500/20 text-success-700 dark:text-success-300`;
+      }
+      if (index === selectedIndex && index !== correctIndex) {
+        return `${base} border-error-500 bg-error-500/20 text-error-700 dark:text-error-300`;
+      }
+      return `${base} border-surface-300 dark:border-surface-600 opacity-50`;
+    }
+    if (index === selectedIndex) {
+      return `${base} border-primary-500 bg-primary-500/20 text-primary-700 dark:text-primary-300`;
+    }
+    if (disabled) {
+      return `${base} border-surface-300 dark:border-surface-600 opacity-50 cursor-not-allowed`;
+    }
+    return `${base} border-surface-300 dark:border-surface-600 hover:border-primary-400 hover:bg-primary-500/10 cursor-pointer`;
+  }
+
+  const totalResponses = $derived(distribution ? distribution.reduce((a, b) => a + b, 0) : 0);
+</script>
+
+<div class="space-y-4">
+  <div class="flex items-start gap-3">
+    <span class="bg-primary-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold shrink-0">
+      {questionIndex + 1}
+    </span>
+    <div>
+      <p class="text-lg font-medium">{text}</p>
+      {#if questionType === "true-false"}
+        <span class="text-xs text-surface-500 uppercase tracking-wide">True / False</span>
+      {/if}
+    </div>
+  </div>
+
+  <div class="grid gap-2 ml-11">
+    {#each options as option, i}
+      <button
+        class={optionClass(i)}
+        onclick={() => handleSelect(i)}
+        disabled={disabled}
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <span class="w-7 h-7 rounded-full border-[1px] border-current flex items-center justify-center text-sm font-medium shrink-0">
+              {String.fromCharCode(65 + i)}
+            </span>
+            <span>{option}</span>
+          </div>
+          {#if showCorrect && correctIndex !== undefined}
+            {#if i === correctIndex}
+              <span class="text-success-500 text-sm font-medium">Correct</span>
+            {:else if i === selectedIndex}
+              <span class="text-error-500 text-sm font-medium">Your answer</span>
+            {/if}
+          {/if}
+        </div>
+        {#if distribution && totalResponses > 0}
+          <div class="mt-2 flex items-center gap-2">
+            <div class="flex-1 h-2 bg-surface-200 dark:bg-surface-700 rounded-full overflow-hidden">
+              <div
+                class="h-full rounded-full {showCorrect && i === correctIndex ? 'bg-success-500' : 'bg-primary-400 dark:bg-primary-600'}"
+                style="width: {(distribution[i] / totalResponses) * 100}%"
+              ></div>
+            </div>
+            <span class="text-xs text-surface-500 w-12 text-right">
+              {distribution[i]} ({Math.round((distribution[i] / totalResponses) * 100)}%)
+            </span>
+          </div>
+        {/if}
+      </button>
+    {/each}
+  </div>
+</div>

--- a/src/lib/ui/quiz/QuizResults.svelte
+++ b/src/lib/ui/quiz/QuizResults.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { computeQuestionAnalytics } from "$lib/services/quiz";
+  import type { Quiz, QuizResponse } from "$lib/services/quiz";
+  import QuizResultsChart from "./QuizResultsChart.svelte";
+
+  interface Props {
+    quiz: Quiz;
+    responses: QuizResponse[];
+    studentId?: string;
+  }
+
+  let { quiz, responses, studentId }: Props = $props();
+
+  const filteredResponses = $derived(
+    studentId ? responses.filter((r) => r.studentId === studentId) : responses
+  );
+
+  const analytics = $derived(computeQuestionAnalytics(filteredResponses, quiz.questions));
+
+  const overallCorrect = $derived(filteredResponses.filter((r) => r.isCorrect).length);
+  const overallTotal = $derived(quiz.questions.length);
+  const overallPct = $derived(overallTotal > 0 ? Math.round((overallCorrect / overallTotal) * 100) : 0);
+
+  const uniqueStudents = $derived(new Set(responses.map((r) => r.studentId)).size);
+  const avgTime = $derived(
+    filteredResponses.length > 0
+      ? Math.round(filteredResponses.reduce((a, r) => a + r.responseTimeMs, 0) / filteredResponses.length / 1000 * 10) / 10
+      : 0
+  );
+</script>
+
+<div class="space-y-6">
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+      <div class="text-3xl font-bold text-primary-500">{overallCorrect}/{overallTotal}</div>
+      <div class="text-sm text-surface-500">{studentId ? "Your Score" : "Avg Score"}</div>
+    </div>
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+      <div class="text-3xl font-bold {overallPct >= 70 ? 'text-success-500' : overallPct >= 40 ? 'text-warning-500' : 'text-error-500'}">
+        {overallPct}%
+      </div>
+      <div class="text-sm text-surface-500">Correct</div>
+    </div>
+    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+      <div class="text-3xl font-bold">{avgTime}s</div>
+      <div class="text-sm text-surface-500">Avg Time</div>
+    </div>
+    {#if !studentId}
+      <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 text-center">
+        <div class="text-3xl font-bold">{uniqueStudents}</div>
+        <div class="text-sm text-surface-500">Participants</div>
+      </div>
+    {/if}
+  </div>
+
+  <div class="space-y-6">
+    {#each quiz.questions as question, i}
+      {@const qa = analytics[i]}
+      {@const studentResponse = studentId ? filteredResponses.find((r) => r.questionId === question.id) : null}
+      <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4">
+        <div class="flex items-start gap-3 mb-4">
+          <span class="bg-primary-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm font-bold shrink-0">
+            {i + 1}
+          </span>
+          <div class="flex-1">
+            <p class="font-medium">{question.text}</p>
+            <div class="flex gap-4 mt-1 text-xs text-surface-500">
+              <span>{qa.totalResponses} responses</span>
+              <span>{qa.correctCount} correct ({qa.totalResponses > 0 ? Math.round((qa.correctCount / qa.totalResponses) * 100) : 0}%)</span>
+              <span>Avg: {(qa.avgResponseTimeMs / 1000).toFixed(1)}s</span>
+            </div>
+          </div>
+          {#if studentResponse}
+            <span class="text-sm font-medium {studentResponse.isCorrect ? 'text-success-500' : 'text-error-500'}">
+              {studentResponse.isCorrect ? "Correct" : "Incorrect"}
+            </span>
+          {/if}
+        </div>
+        <QuizResultsChart
+          options={question.options}
+          distribution={qa.distribution}
+          correctIndex={question.correctIndex}
+        />
+      </div>
+    {/each}
+  </div>
+</div>

--- a/src/lib/ui/quiz/QuizResultsChart.svelte
+++ b/src/lib/ui/quiz/QuizResultsChart.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  interface Props {
+    options: string[];
+    distribution: number[];
+    correctIndex: number;
+  }
+
+  let { options, distribution, correctIndex }: Props = $props();
+
+  const total = $derived(distribution.reduce((a, b) => a + b, 0));
+</script>
+
+<div class="space-y-2">
+  {#each options as option, i}
+    {@const count = distribution[i] ?? 0}
+    {@const pct = total > 0 ? Math.round((count / total) * 100) : 0}
+    <div class="flex items-center gap-3">
+      <span class="w-7 h-7 rounded-full border-[1px] flex items-center justify-center text-xs font-medium shrink-0
+        {i === correctIndex ? 'border-success-500 text-success-500' : 'border-surface-400 text-surface-500'}">
+        {String.fromCharCode(65 + i)}
+      </span>
+      <span class="w-28 text-sm truncate" title={option}>{option}</span>
+      <div class="flex-1 h-6 bg-surface-200 dark:bg-surface-700 rounded overflow-hidden">
+        <div
+          class="h-full rounded transition-all duration-500 {i === correctIndex ? 'bg-success-500' : 'bg-primary-300 dark:bg-primary-700'}"
+          style="width: {pct}%"
+        ></div>
+      </div>
+      <span class="w-16 text-xs text-right text-surface-500">{count} ({pct}%)</span>
+    </div>
+  {/each}
+</div>

--- a/src/routes/(course-reader)/+layout.svelte
+++ b/src/routes/(course-reader)/+layout.svelte
@@ -5,6 +5,7 @@
   import { page } from "$app/state";
   import { currentCourse } from "$lib/runes.svelte";
   import { afterNavigate } from "$app/navigation";
+  import QuizNotificationListener from "$lib/ui/quiz/QuizNotificationListener.svelte";
 
   type Props = { children: Snippet };
   let { children }: Props = $props();
@@ -35,6 +36,7 @@
   <title>{currentCourse?.value?.title}</title>
 </svelte:head>
 
+<QuizNotificationListener />
 <CourseShell>
   <span id="content-panel" class="mt-[-60px] block pt-[60px]"></span>
 

--- a/src/routes/(course-reader)/quiz/[courseid]/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import SecondaryNavigator from "$lib/ui/navigators/SecondaryNavigator.svelte";
+  import QuizDashboard from "$lib/ui/quiz/QuizDashboard.svelte";
+
+  interface Props {
+    data: any;
+  }
+  let { data }: Props = $props();
+</script>
+
+<svelte:head>
+  <title>Quizzes</title>
+</svelte:head>
+
+<SecondaryNavigator lo={data?.lo} parentCourse={data.lo?.parentCourse?.properties?.parent} />
+<div class="w-full max-w-4xl mx-auto">
+  <QuizDashboard />
+</div>

--- a/src/routes/(course-reader)/quiz/[courseid]/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/+page.ts
@@ -1,0 +1,10 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  return { course, lo: course };
+};

--- a/src/routes/(course-reader)/quiz/[courseid]/[...loid]/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/[...loid]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { PageData } from "./$types";
+  import Context from "$lib/ui/learning-objects/structure/Context.svelte";
+  import QuizLo from "$lib/ui/learning-objects/content/QuizLo.svelte";
+
+  interface Props {
+    data: PageData;
+  }
+  let { data }: Props = $props();
+</script>
+
+<Context lo={data.lo}>
+  <QuizLo lo={data.lo} />
+</Context>

--- a/src/routes/(course-reader)/quiz/[courseid]/[...loid]/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/[...loid]/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from "./$types";
+import { courseService } from "$lib/services/course";
+
+export const ssr = false;
+
+export const load: PageLoad = async ({ url, params, fetch }) => {
+  const lo = await courseService.readLo(params.courseid, url.pathname, fetch);
+  return {
+    lo: lo
+  };
+};

--- a/src/routes/(course-reader)/quiz/[courseid]/[quizid]/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/[quizid]/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse, tutorsId } from "$lib/runes.svelte";
+  import { isLecturer, createSession, getActiveSession } from "$lib/services/quiz";
+  import type { Quiz, QuizSession } from "$lib/services/quiz";
+  import SecondaryNavigator from "$lib/ui/navigators/SecondaryNavigator.svelte";
+  import QuizCreator from "$lib/ui/quiz/QuizCreator.svelte";
+  import QuizAsync from "$lib/ui/quiz/QuizAsync.svelte";
+
+  interface Props {
+    data: { course: any; lo: any; quiz: Quiz | null };
+  }
+  let { data }: Props = $props();
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+  const lecturer = $derived(isLecturer(currentCourse.value, tutorsId.value?.login));
+
+  let activeSession = $state<QuizSession | null>(null);
+
+  $effect(() => {
+    if (courseId) {
+      getActiveSession(courseId).then((s) => {
+        activeSession = s;
+      });
+    }
+  });
+
+  async function handleStartSession() {
+    if (!data.quiz) return;
+    const session = await createSession(data.quiz.id, courseId, tutorsId.value!.login);
+    if (session) {
+      goto(`/quiz/${courseId}/live/${session.id}`);
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>{data.quiz?.title ?? "Quiz"}</title>
+</svelte:head>
+
+<SecondaryNavigator lo={data?.lo} parentCourse={data.lo?.parentCourse?.properties?.parent} />
+
+{#if !data.quiz}
+  <div class="text-center py-12 text-surface-500">Quiz not found</div>
+{:else if lecturer}
+  <div class="w-full max-w-4xl mx-auto">
+    <div class="mx-4 mt-4 flex items-center justify-between mb-4">
+      <h2 class="text-xl font-bold">{data.quiz.title}</h2>
+      <div class="flex gap-2">
+        <button
+          class="px-3 py-1.5 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+          onclick={() => goto(`/quiz/${courseId}/${data.quiz!.id}/results`)}
+        >
+          View Results
+        </button>
+        <button
+          class="px-3 py-1.5 rounded-lg text-sm preset-filled-primary-500"
+          onclick={handleStartSession}
+          disabled={activeSession !== null}
+        >
+          {activeSession ? "Session Active" : "Start Live Session"}
+        </button>
+      </div>
+    </div>
+    <QuizCreator existingQuiz={data.quiz} />
+  </div>
+{:else if data.quiz.status === "published"}
+  <div class="w-full max-w-4xl mx-auto">
+    <QuizAsync quiz={data.quiz} />
+  </div>
+{:else}
+  <div class="text-center py-12 text-surface-500">This quiz is not available</div>
+{/if}

--- a/src/routes/(course-reader)/quiz/[courseid]/[quizid]/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/[quizid]/+page.ts
@@ -1,0 +1,12 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+import { getQuizById } from "$lib/services/quiz";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  const quiz = await getQuizById(params.quizid);
+  return { course, lo: course, quiz };
+};

--- a/src/routes/(course-reader)/quiz/[courseid]/[quizid]/results/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/[quizid]/results/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse, tutorsId } from "$lib/runes.svelte";
+  import { isLecturer } from "$lib/services/quiz";
+  import type { Quiz, QuizResponse } from "$lib/services/quiz";
+  import SecondaryNavigator from "$lib/ui/navigators/SecondaryNavigator.svelte";
+  import QuizResults from "$lib/ui/quiz/QuizResults.svelte";
+
+  interface Props {
+    data: { course: any; lo: any; quiz: Quiz | null; responses: QuizResponse[] };
+  }
+  let { data }: Props = $props();
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+  const lecturer = $derived(isLecturer(currentCourse.value, tutorsId.value?.login));
+  const studentId = $derived(tutorsId.value?.login);
+</script>
+
+<svelte:head>
+  <title>{data.quiz?.title ?? "Quiz"} - Results</title>
+</svelte:head>
+
+<SecondaryNavigator lo={data?.lo} parentCourse={data.lo?.parentCourse?.properties?.parent} />
+
+{#if !data.quiz}
+  <div class="text-center py-12 text-surface-500">Quiz not found</div>
+{:else}
+  <div class="w-full max-w-4xl mx-auto mx-4 mt-4">
+    <div class="flex items-center justify-between mb-6 mx-4">
+      <h2 class="text-xl font-bold">{data.quiz.title} - Results</h2>
+      <button
+        class="px-3 py-1.5 rounded-lg text-sm border-[1px] border-surface-300 dark:border-surface-600 hover:bg-surface-200 dark:hover:bg-surface-800"
+        onclick={() => goto(`/quiz/${courseId}`)}
+      >
+        Back to Quizzes
+      </button>
+    </div>
+    <div class="mx-4">
+      <QuizResults
+        quiz={data.quiz}
+        responses={data.responses}
+        studentId={lecturer ? undefined : studentId}
+      />
+    </div>
+  </div>
+{/if}

--- a/src/routes/(course-reader)/quiz/[courseid]/[quizid]/results/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/[quizid]/results/+page.ts
@@ -1,0 +1,13 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+import { getQuizById, getResponsesForQuiz } from "$lib/services/quiz";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  const quiz = await getQuizById(params.quizid);
+  const responses = quiz ? await getResponsesForQuiz(quiz.id) : [];
+  return { course, lo: course, quiz, responses };
+};

--- a/src/routes/(course-reader)/quiz/[courseid]/create/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/create/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { currentCourse, tutorsId } from "$lib/runes.svelte";
+  import { isLecturer } from "$lib/services/quiz";
+  import SecondaryNavigator from "$lib/ui/navigators/SecondaryNavigator.svelte";
+  import QuizCreator from "$lib/ui/quiz/QuizCreator.svelte";
+
+  interface Props {
+    data: any;
+  }
+  let { data }: Props = $props();
+
+  const courseId = $derived(currentCourse.value?.courseId ?? "");
+  const lecturer = $derived(isLecturer(currentCourse.value, tutorsId.value?.login));
+
+  $effect(() => {
+    if (courseId && !lecturer) {
+      goto(`/quiz/${courseId}`);
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Create Quiz</title>
+</svelte:head>
+
+<SecondaryNavigator lo={data?.lo} parentCourse={data.lo?.parentCourse?.properties?.parent} />
+{#if lecturer}
+  <div class="w-full max-w-4xl mx-auto">
+    <QuizCreator />
+  </div>
+{/if}

--- a/src/routes/(course-reader)/quiz/[courseid]/create/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/create/+page.ts
@@ -1,0 +1,10 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  return { course, lo: course };
+};

--- a/src/routes/(course-reader)/quiz/[courseid]/live/[sessionid]/+page.svelte
+++ b/src/routes/(course-reader)/quiz/[courseid]/live/[sessionid]/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import { PUBLIC_ANON_MODE } from "$env/static/public";
+  import { currentCourse, tutorsId } from "$lib/runes.svelte";
+  import { isLecturer } from "$lib/services/quiz";
+  import QuizLiveHost from "$lib/ui/quiz/QuizLiveHost.svelte";
+  import QuizLiveStudent from "$lib/ui/quiz/QuizLiveStudent.svelte";
+  import SecondaryNavigator from "$lib/ui/navigators/SecondaryNavigator.svelte";
+
+  interface Props {
+    data: { course: any; lo: any; sessionId: string };
+  }
+  let { data }: Props = $props();
+
+  const isHost = $derived(
+    (browser && sessionStorage.getItem("quizHostSession") === data.sessionId) ||
+    (PUBLIC_ANON_MODE !== "TRUE" && isLecturer(currentCourse.value, tutorsId.value?.login))
+  );
+</script>
+
+<svelte:head>
+  <title>Live Quiz</title>
+</svelte:head>
+
+<SecondaryNavigator lo={data?.lo} parentCourse={data.lo?.parentCourse?.properties?.parent} />
+
+{#if isHost}
+  <QuizLiveHost sessionId={data.sessionId} />
+{:else}
+  <QuizLiveStudent sessionId={data.sessionId} />
+{/if}

--- a/src/routes/(course-reader)/quiz/[courseid]/live/[sessionid]/+page.ts
+++ b/src/routes/(course-reader)/quiz/[courseid]/live/[sessionid]/+page.ts
@@ -1,0 +1,10 @@
+import { currentCourse } from "$lib/runes.svelte";
+import { courseService } from "$lib/services/course";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  return { course, lo: course, sessionId: params.sessionid };
+};

--- a/src/routes/(course-reader)/search/[courseid]/+page.svelte
+++ b/src/routes/(course-reader)/search/[courseid]/+page.svelte
@@ -36,7 +36,8 @@
     const steps = filterByType(data.course.los, "step");
     const notes = filterByType(data.course.los, "note");
     const panelNotes = filterByType(data.course.los, "panelnote");
-    searchLos.push(...labs, ...steps, ...notes, ...panelNotes);
+    const quizzes = filterByType(data.course.los, "quiz");
+    searchLos.push(...labs, ...steps, ...notes, ...panelNotes, ...quizzes);
     searchInputElement.focus();
   });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,9 @@
   import { browser } from "$app/environment";
   import { themeService } from "$lib/services/themes/services/themes.svelte";
   import { locale, SUPPORTED_LOCALES } from "$lib/services/i18n";
+  import { goto } from "$app/navigation";
+  import { Toast } from "@skeletonlabs/skeleton-svelte";
+  import { toaster } from "$lib/stores/toaster";
 
   interface Props {
     data: PageData;
@@ -31,3 +34,27 @@
 </script>
 
 {@render children()}
+
+<Toast.Group {toaster}>
+  {#snippet children(toast)}
+    <Toast {toast} class="border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-900 rounded-xl border-[1px] p-4 shadow-lg">
+      <div class="flex items-start gap-3">
+        <div class="flex-1">
+          <Toast.Title class="font-bold text-sm">{toast.title}</Toast.Title>
+          <Toast.Description class="text-sm text-surface-500 mt-1">{toast.description}</Toast.Description>
+        </div>
+        <div class="flex items-center gap-2">
+          {#if toast.meta?.actionUrl}
+            <button
+              class="px-3 py-1.5 rounded-lg text-xs font-medium preset-filled-primary-500"
+              onclick={() => { toaster.dismiss(toast.id); goto(toast.meta.actionUrl); }}
+            >
+              {toast.meta.actionLabel ?? "Go"}
+            </button>
+          {/if}
+          <Toast.CloseTrigger class="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300 text-lg leading-none">&times;</Toast.CloseTrigger>
+        </div>
+      </div>
+    </Toast>
+  {/snippet}
+</Toast.Group>


### PR DESCRIPTION
## Summary
- Adds **quiz** as a first-class learning object in Tutors
- Course authors embed quizzes via `quiz-*` folders with `quiz.md` definitions
- **Live quizzes**: lecturers run real-time sessions with PartyKit/BroadcastChannel, students join and vote
- **Async quizzes**: students take quizzes at their own pace with instant feedback
- Includes quiz dashboard, creator, results analytics, toast notifications, and course-embedded quiz elevation
- Quiz LOs from the course tree are automatically surfaced on the Quiz Dashboard

## New files
- `src/lib/services/quiz/` — quiz service (types, parser, session state, CRUD, utils)
- `src/lib/stores/toaster.ts` — shared toast notification store
- `src/lib/ui/quiz/` — all quiz UI components (Dashboard, Creator, LiveHost, LiveStudent, Question, Results, ResultsChart, NotificationListener)
- `src/lib/ui/learning-objects/content/QuizLo.svelte` — quiz LO renderer
- `src/lib/ui/navigators/buttons/QuizButton.svelte` — nav bar quiz button
- `src/routes/(course-reader)/quiz/` — all quiz routes

## Modified files
- Community presence service — quiz notification handling
- Course service — quiz cache and LO tree support
- Markdown renderer — quiz fence block support
- Icon themes — quiz icon entries
- Lab/Note — `use:quizify` action for embedded quiz rendering
- Main navigator — QuizButton
- Layout files — QuizNotificationListener and Toast.Group

## Related PRs (quiz feature series)
1. **tutors reader** (this PR): https://github.com/tutors-sdk/tutors/pull/1093
2. **tutors-apps**: https://github.com/tutors-sdk/tutors-apps/pull/18 — adds `"quiz"` to `simpleTypes` so the CLI recognizes `quiz-*` folders
3. **tutors-reference-course**: https://github.com/tutors-sdk/tutors-reference-course/pull/3 — sample quiz content for testing

## Test plan
- [ ] Create a course with `quiz-*` folders containing `quiz.md` files
- [ ] Verify quiz dashboard shows course-embedded quizzes
- [ ] Test live quiz flow: start session → students join → vote → reveal → results
- [ ] Test async quiz flow: take quiz → see results
- [ ] Verify toast notifications appear in other tabs when a live quiz starts
- [ ] Verify quiz search integration works

🤖 Generated with [Claude Code](https://claude.com/claude-code)