### PR TITLE
DO NOT MERGE: Add configurable course base domain and container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.svelte-kit
+build
+.env
+.env.local
+.git
+.github
+.husky
+coverage
+.stryker-tmp

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ PUBLIC_party_kit_main_room="XXX"
 
 # pdf key
 PUBLIC_PDF_KEY="XXX"
+
+# Base domain suffix for course content (default: .netlify.app)
+# Examples: .netlify.app, .apps.ocp4.example.com
+PUBLIC_COURSE_BASE_DOMAIN=".netlify.app"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+COPY svelte.config.node.js svelte.config.js
+
+ARG PUBLIC_ANON_MODE=TRUE
+ARG PUBLIC_SUPABASE_URL=""
+ARG PUBLIC_SUPABASE_ANON_KEY=""
+ARG PUBLIC_party_kit_main_room=""
+ARG PUBLIC_PDF_KEY=""
+ARG PUBLIC_COURSE_BASE_DOMAIN=".netlify.app"
+
+ENV PUBLIC_ANON_MODE=$PUBLIC_ANON_MODE
+ENV PUBLIC_SUPABASE_URL=$PUBLIC_SUPABASE_URL
+ENV PUBLIC_SUPABASE_ANON_KEY=$PUBLIC_SUPABASE_ANON_KEY
+ENV PUBLIC_party_kit_main_room=$PUBLIC_party_kit_main_room
+ENV PUBLIC_PDF_KEY=$PUBLIC_PDF_KEY
+ENV PUBLIC_COURSE_BASE_DOMAIN=$PUBLIC_COURSE_BASE_DOMAIN
+
+RUN npm run build
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/package.json ./
+
+ENV PORT=3000
+ENV HOST=0.0.0.0
+
+EXPOSE 3000
+
+CMD ["node", "build/index.js"]

--- a/Dockerfile.course
+++ b/Dockerfile.course
@@ -1,0 +1,44 @@
+# Sample Dockerfile for serving a Tutors course as a static container.
+#
+# Usage:
+#   1. Build your course with tutors-json (produces a directory of JSON + assets)
+#   2. Build the container image:
+#      docker build -f Dockerfile.course --build-arg COURSE_DIR=./my-course-output -t my-course .
+#   3. Run:
+#      docker run -p 8080:8080 my-course
+#
+# The course will be available at http://localhost:8080/tutors.json
+
+FROM nginx:1.27-alpine
+
+ARG COURSE_DIR=./course
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY <<'NGINX' /etc/nginx/conf.d/course.conf
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    add_header Access-Control-Allow-Origin *;
+    add_header Access-Control-Allow-Methods "GET, OPTIONS";
+    add_header Access-Control-Allow-Headers "Content-Type";
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~* \.(json|png|jpg|jpeg|gif|svg|pdf|zip)$ {
+        expires 1h;
+        add_header Cache-Control "public, immutable";
+        add_header Access-Control-Allow-Origin *;
+    }
+}
+NGINX
+
+COPY ${COURSE_DIR} /usr/share/nginx/html/
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@supabase/supabase-js": "^2.108.0",
         "@sveltejs/adapter-auto": "^7.0.1",
         "@sveltejs/adapter-netlify": "^6.0.4",
+        "@sveltejs/adapter-node": "^5.5.7",
         "@sveltejs/kit": "^2.64.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/forms": "^0.5.11",
@@ -208,6 +209,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -899,35 +901,13 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2028,6 +2008,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2268,6 +2249,7 @@
       "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-3.2.2.tgz",
       "integrity": "sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "cssesc": "^3.0.0",
@@ -2456,9 +2438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,9 +2459,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,9 +2480,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2501,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,9 +2522,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2781,9 +2748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2801,9 +2765,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2782,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2799,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2816,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,9 +2833,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2850,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3136,9 +3079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3153,9 +3093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3170,9 +3107,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3187,9 +3121,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,9 +3135,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,9 +3149,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3238,9 +3163,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3255,9 +3177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3485,9 +3404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3505,9 +3421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,9 +3438,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3545,9 +3455,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3565,9 +3472,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3585,9 +3489,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3708,6 +3609,148 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+      "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -3800,9 +3843,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3817,9 +3857,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3834,9 +3871,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3851,9 +3885,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3868,9 +3899,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3885,9 +3913,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3902,9 +3927,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3919,9 +3941,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3936,9 +3955,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3953,9 +3969,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3970,9 +3983,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3987,9 +3997,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4004,9 +4011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5034,12 +5038,30 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/@sveltejs/adapter-node": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.7.tgz",
+      "integrity": "sha512-uOfc9eVlI3A37RRSaKcgrheBYPrfJwC9VMqDp8x/O6tlKdcLLvHThSWD0KNIbjQ/d+7bwLGx3vx6aowAcRfd2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.3",
+        "rollup": "^4.59.0"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.4.0"
+      }
+    },
     "node_modules/@sveltejs/kit": {
       "version": "2.64.0",
       "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.64.0.tgz",
       "integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -5099,6 +5121,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -5269,9 +5292,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5289,9 +5309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5309,9 +5326,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5329,9 +5343,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5934,6 +5945,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5961,9 +5973,17 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
@@ -6040,6 +6060,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -6248,6 +6269,7 @@
       "integrity": "sha512-gIzazUkbQfv6T1rJHOLhMMKQnplKAvvQ7QNGaFwI6oCsp4z2aSDZCojGpX3QX3+MYsvJdyy/8BRIYVEbAkMkEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -6418,6 +6440,7 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -7075,6 +7098,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7282,6 +7306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7659,6 +7684,13 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7743,6 +7775,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8164,6 +8197,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8589,6 +8623,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9363,6 +9398,7 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -9629,6 +9665,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9664,6 +9716,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-node-process": {
       "version": "1.2.0",
@@ -10171,9 +10230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10195,9 +10251,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10219,9 +10272,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10243,9 +10293,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10719,6 +10766,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -11595,6 +11643,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -11770,6 +11825,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11895,6 +11951,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11977,6 +12034,7 @@
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12008,6 +12066,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12024,6 +12083,7 @@
       "integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -12284,6 +12344,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -12984,12 +13066,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/svelte": {
       "version": "5.56.3",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
       "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -13148,7 +13244,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -13417,6 +13514,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13671,6 +13769,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13867,6 +13966,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@supabase/supabase-js": "^2.108.0",
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/adapter-netlify": "^6.0.4",
+    "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/kit": "^2.64.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/forms": "^0.5.11",

--- a/src/lib/services/community/services/catalogue.ts
+++ b/src/lib/services/community/services/catalogue.ts
@@ -1,5 +1,6 @@
 import type { CatalogueEntry, CatalogueService } from "$lib/services/community";
 import { supabase } from "../utils/supabase-client";
+import { courseBaseDomain } from "$lib/services/course/config";
 import log from "$lib/services/logger";
 
 export const catalogueService: CatalogueService = {
@@ -55,7 +56,7 @@ export const catalogueService: CatalogueService = {
     const invalidIds: string[] = [];
     for (const course of catalogue) {
       try {
-        const url = `https://${course.course_id}.netlify.app/tutors.json`;
+        const url = `https://${course.course_id}${courseBaseDomain}/tutors.json`;
         const response = await fetchFunction(url, { method: "HEAD" });
         if (!response.ok) {
           invalidIds.push(course.course_id);

--- a/src/lib/services/course/config.ts
+++ b/src/lib/services/course/config.ts
@@ -1,0 +1,3 @@
+import { PUBLIC_COURSE_BASE_DOMAIN } from "$env/static/public";
+
+export const courseBaseDomain: string = PUBLIC_COURSE_BASE_DOMAIN || ".netlify.app";

--- a/src/lib/services/course/services/__tests__/lo-tree-configurable-domain.test.ts
+++ b/src/lib/services/course/services/__tests__/lo-tree-configurable-domain.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { determineCourseUrl } from "../lo-tree";
+import { courseProtocol } from "$lib/runes.svelte";
+
+describe("determineCourseUrl() with custom baseDomain", () => {
+  beforeEach(() => {
+    courseProtocol.value = "https://";
+  });
+
+  describe("WHEN a plain course ID is provided with custom domain", () => {
+    it("should construct URL using the custom domain suffix", () => {
+      const result = determineCourseUrl("my-course", ".apps.ocp4.example.com");
+      expect(result.courseId).toBe("my-course");
+      expect(result.courseUrl).toBe("my-course.apps.ocp4.example.com");
+    });
+
+    it("should work with different domain suffixes", () => {
+      const result = determineCourseUrl("web-dev-2024", ".courses.university.edu");
+      expect(result.courseId).toBe("web-dev-2024");
+      expect(result.courseUrl).toBe("web-dev-2024.courses.university.edu");
+    });
+  });
+
+  describe("WHEN a full URL containing the custom domain is provided", () => {
+    it("should strip the custom domain from courseId", () => {
+      const result = determineCourseUrl("my-course.apps.ocp4.example.com", ".apps.ocp4.example.com");
+      expect(result.courseId).toBe("my-course");
+      expect(result.courseUrl).toBe("my-course.apps.ocp4.example.com");
+    });
+
+    it("should not strip domain if it does not match", () => {
+      const result = determineCourseUrl("my-course.other-domain.com", ".apps.ocp4.example.com");
+      expect(result.courseId).toBe("my-course.other-domain.com");
+      expect(result.courseUrl).toBe("my-course.other-domain.com");
+    });
+  });
+
+  describe("WHEN localhost is provided with custom domain", () => {
+    it("should ignore the custom domain and use localhost directly", () => {
+      const result = determineCourseUrl("localhost:3000", ".apps.ocp4.example.com");
+      expect(result.courseId).toBe("localhost:3000");
+      expect(result.courseUrl).toBe("localhost:3000");
+      expect(courseProtocol.value).toBe("http://");
+    });
+
+    it("should ignore the custom domain for IP addresses", () => {
+      const result = determineCourseUrl("192.168.1.100:8080", ".apps.ocp4.example.com");
+      expect(result.courseId).toBe("192.168.1.100:8080");
+      expect(result.courseUrl).toBe("192.168.1.100:8080");
+      expect(courseProtocol.value).toBe("http://");
+    });
+  });
+
+  describe("WHEN no baseDomain is provided", () => {
+    it("should default to .netlify.app for plain course IDs", () => {
+      const result = determineCourseUrl("my-course");
+      expect(result.courseUrl).toBe("my-course.netlify.app");
+    });
+  });
+});

--- a/src/lib/services/course/services/lo-tree.ts
+++ b/src/lib/services/course/services/lo-tree.ts
@@ -1,4 +1,5 @@
 import { courseProtocol } from "$lib/runes.svelte";
+import { courseBaseDomain } from "$lib/services/course/config";
 import {
   allVideoLos,
   convertLoToHtml,
@@ -155,28 +156,26 @@ function localizePath(lo: Lo) {
 
 /**
  * Determines the course URL and normalized course ID from various input formats.
- * Handles full URLs, Netlify domains, localhost/IP addresses, and plain course IDs.
+ * Handles full URLs, localhost/IP addresses, and plain course IDs.
  * @param input - Course identifier (URL, domain, or ID)
+ * @param baseDomain - Domain suffix for plain course IDs (default: from PUBLIC_COURSE_BASE_DOMAIN env var)
  * @returns Object with normalized courseId and courseUrl
  */
-export function determineCourseUrl(input: string): { courseId: string; courseUrl: string } {
+export function determineCourseUrl(input: string, baseDomain: string = courseBaseDomain): { courseId: string; courseUrl: string } {
   const urlPattern = /^(https?:\/\/)?([A-Za-z0-9.-]+\.[A-Za-z]{2,})(:[0-9]+)?(\/[A-Za-z0-9_.-]+)*(\/[A-Za-z0-9_.-]+\?[A-Za-z0-9_=-]+)?(#.*)?$/;
   const isValidURL = urlPattern.test(input);
 
   if (isValidURL) {
-    // Full URL provided (e.g., https://example.netlify.app)
     const courseUrl = input;
-    const courseId = input.includes(".netlify.app") ? input.replace(".netlify.app", "") : input;
+    const courseId = input.includes(baseDomain) ? input.replace(baseDomain, "") : input;
     return { courseId, courseUrl };
   }
 
-  // Course ID only - determine protocol and construct URL
   const isLocalhost = input.startsWith("192") || input.startsWith("localhost");
   if (isLocalhost) {
     courseProtocol.value = "http://";
     return { courseId: input, courseUrl: input };
   }
 
-  // Default to Netlify subdomain
-  return { courseId: input, courseUrl: `${input}.netlify.app` };
+  return { courseId: input, courseUrl: `${input}${baseDomain}` };
 }

--- a/svelte.config.node.js
+++ b/svelte.config.node.js
@@ -1,0 +1,18 @@
+import adapter from "@sveltejs/adapter-node";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+
+  onwarn(warning, defaultHandler) {
+    if (warning.code === 'state_referenced_locally') return;
+    defaultHandler(warning);
+  },
+
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;

--- a/tests/mocks/env-static-public.ts
+++ b/tests/mocks/env-static-public.ts
@@ -1,0 +1,6 @@
+export const PUBLIC_COURSE_BASE_DOMAIN = ".netlify.app";
+export const PUBLIC_ANON_MODE = "TRUE";
+export const PUBLIC_SUPABASE_URL = "";
+export const PUBLIC_SUPABASE_ANON_KEY = "";
+export const PUBLIC_party_kit_main_room = "";
+export const PUBLIC_PDF_KEY = "";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,7 +58,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '$lib': path.resolve('./src/lib'),
-      '$app': path.resolve('./node_modules/@sveltejs/kit/src/runtime/app')
+      '$app': path.resolve('./node_modules/@sveltejs/kit/src/runtime/app'),
+      '$env/static/public': path.resolve('./tests/mocks/env-static-public.ts')
     }
   }
 });


### PR DESCRIPTION
## DO NOT MERGE — Testing/Experimental

This PR is a proof of concept for deploying Tutors on Kubernetes/OpenShift. Not ready for production.

## Summary

- Replace hardcoded `.netlify.app` domain in course URL resolution with a configurable `PUBLIC_COURSE_BASE_DOMAIN` environment variable (defaults to `.netlify.app` for backward compatibility)
- Add `Dockerfile` for building the reader as a Node.js container (multi-stage build using `adapter-node`)
- Add `Dockerfile.course` as a sample nginx container for serving static course content with CORS headers
- Add `svelte.config.node.js` so container builds use `adapter-node` while the repo default stays `adapter-auto` (Netlify unaffected)

## Architecture

**Approach 1**: Reader deployed centrally on OpenShift, courses served from configurable locations (other containers, student machines, or existing Netlify sites).

```
Student machine                    OpenShift cluster
┌─────────────────┐               ┌──────────────────┐
│ Course container │◄──fetch──────│  Reader (SvelteKit)│
│ (nginx, :8080)  │   tutors.json │  (node, :3000)    │
└─────────────────┘               └──────────────────┘
```

## Files changed

| File | Change |
|------|--------|
| `src/lib/services/course/config.ts` | New — centralizes `PUBLIC_COURSE_BASE_DOMAIN` with fallback |
| `src/lib/services/course/services/lo-tree.ts` | `determineCourseUrl()` accepts optional `baseDomain` param |
| `src/lib/services/community/services/catalogue.ts` | Uses configurable domain for catalogue pruning |
| `.env.example` | Documents `PUBLIC_COURSE_BASE_DOMAIN` |
| `Dockerfile` | Multi-stage reader container |
| `Dockerfile.course` | Sample course container (nginx + CORS) |
| `svelte.config.node.js` | adapter-node config for container builds |
| `.dockerignore` | Build context exclusions |
| `vitest.config.ts` | Alias for `$env/static/public` in tests |
| `tests/mocks/env-static-public.ts` | Mock env vars for test runner |

## Test plan

- [x] All existing `determineCourseUrl()` tests pass (backward compatible)
- [x] New configurable domain tests pass (7/7)
- [x] `npm run build` succeeds
- [ ] Docker build and run the reader container
- [ ] Docker build and run a course container
- [ ] Verify reader fetches course from custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)