### PR TITLE
Add Cmd+K search overlay with MiniSearch indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@tutors/tutors-time-lib": "npm:@jsr/tutors__tutors-time-lib@^5.0.4",
         "codemirror": "^6.0.2",
         "dompurify": "^3.4.12",
-        "mermaid": "^11.16.0"
+        "mermaid": "^11.16.0",
+        "minisearch": "^7.2.0"
       },
       "devDependencies": {
         "@auth/core": "^0.41.2",
@@ -208,6 +209,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -899,35 +901,13 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2028,6 +2008,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2268,6 +2249,7 @@
       "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-3.2.2.tgz",
       "integrity": "sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "cssesc": "^3.0.0",
@@ -2456,9 +2438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,9 +2459,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,9 +2480,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2501,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,9 +2522,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2781,9 +2748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2801,9 +2765,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2782,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2799,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2816,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,9 +2833,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2850,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3136,9 +3079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3153,9 +3093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3170,9 +3107,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3187,9 +3121,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,9 +3135,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,9 +3149,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3238,9 +3163,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3255,9 +3177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3485,9 +3404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3505,9 +3421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,9 +3438,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3545,9 +3455,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3565,9 +3472,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3585,9 +3489,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3800,9 +3701,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3817,9 +3715,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3834,9 +3729,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3851,9 +3743,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3868,9 +3757,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3885,9 +3771,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3902,9 +3785,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3919,9 +3799,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3936,9 +3813,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3953,9 +3827,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3970,9 +3841,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3987,9 +3855,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4004,9 +3869,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5040,6 +4902,7 @@
       "integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -5099,6 +4962,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -5269,9 +5133,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5289,9 +5150,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5309,9 +5167,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5329,9 +5184,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5934,6 +5786,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5961,6 +5814,7 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6040,6 +5894,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -6147,6 +6002,7 @@
       "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6248,6 +6104,7 @@
       "integrity": "sha512-gIzazUkbQfv6T1rJHOLhMMKQnplKAvvQ7QNGaFwI6oCsp4z2aSDZCojGpX3QX3+MYsvJdyy/8BRIYVEbAkMkEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -6418,6 +6275,7 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -7075,6 +6933,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7282,6 +7141,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7743,6 +7603,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8164,6 +8025,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8525,6 +8387,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8589,6 +8452,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9363,6 +9227,7 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -10171,9 +10036,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10195,9 +10057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10219,9 +10078,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10243,9 +10099,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10719,6 +10572,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -11118,6 +10972,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/mj-context-menu": {
       "version": "0.6.1",
@@ -11770,6 +11630,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11895,6 +11756,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11977,6 +11839,7 @@
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12008,6 +11871,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12024,6 +11888,7 @@
       "integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -12990,6 +12855,7 @@
       "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -13148,7 +13014,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -13417,6 +13284,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13671,6 +13539,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13867,6 +13736,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@tutors/tutors-time-lib": "npm:@jsr/tutors__tutors-time-lib@^5.0.4",
     "codemirror": "^6.0.2",
     "dompurify": "^3.4.12",
-    "mermaid": "^11.16.0"
+    "mermaid": "^11.16.0",
+    "minisearch": "^7.2.0"
   }
 }

--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -25,3 +25,5 @@ export const tutorsId = rune<TutorsId | null>(null);
 export const courseProtocol = rune("https://");
 
 export const hideMainNavigator = rune(false);
+
+export const searchOpen = rune(false);

--- a/src/lib/services/course/services/course.svelte.ts
+++ b/src/lib/services/course/services/course.svelte.ts
@@ -11,6 +11,7 @@ import { courseProtocol, currentCourse, currentLo, rune } from "$lib/runes.svelt
 import type { CourseService, LabService, NotebookService } from "../types";
 import type { NotebookLo } from "$lib/types/notebook-types";
 import { decorateCourseTree, determineCourseUrl } from "./lo-tree";
+import { searchService } from "$lib/services/search";
 import log from "$lib/services/logger";
 
 export const courseService: CourseService = {
@@ -47,6 +48,7 @@ export const courseService: CourseService = {
         course = data as Course;
         decorateCourseTree(course, courseId, courseUrl);
         this.courses.set(courseId, course);
+        searchService.buildIndex(course);
       } catch (error) {
         log.error(`Error fetching from URL: https://${courseUrl}/tutors.json`);
         log.error(error);

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -66,6 +66,14 @@ const de: Record<string, string> = {
   "home.credits.description": "Tutors ist ein Open-Source-Projekt, das kostenlos unter der MIT-Lizenz auf GitHub verfuegbar ist.",
   "home.credits.viewSource": "Quellcode anzeigen",
 
+  // Search overlay
+  "search.placeholder": "Diesen Kurs durchsuchen...",
+  "search.noResults": "Keine Ergebnisse gefunden",
+  "search.shortcut": "zum Suchen",
+  "search.navigate": "zum Navigieren",
+  "search.select": "zum Auswaehlen",
+  "search.close": "Suche schliessen",
+
   // Course reader
   "course.search.label": "Suchbegriff eingeben:",
   "course.search.button": "Suchen",

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -66,6 +66,14 @@ const en = {
   "home.credits.description": "Tutors is an open source project available for free under the MIT license on GitHub.",
   "home.credits.viewSource": "View Source Code",
 
+  // Search overlay
+  "search.placeholder": "Search this course...",
+  "search.noResults": "No results found",
+  "search.shortcut": "to search",
+  "search.navigate": "to navigate",
+  "search.select": "to select",
+  "search.close": "Close search",
+
   // Course reader
   "course.search.label": "Enter search term:",
   "course.search.button": "Search",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -66,6 +66,14 @@ const es: Record<string, string> = {
   "home.credits.description": "Tutors es un proyecto de codigo abierto disponible de forma gratuita en GitHub bajo la licencia MIT.",
   "home.credits.viewSource": "Ver codigo fuente",
 
+  // Search overlay
+  "search.placeholder": "Buscar en este curso...",
+  "search.noResults": "No se encontraron resultados",
+  "search.shortcut": "para buscar",
+  "search.navigate": "para navegar",
+  "search.select": "para seleccionar",
+  "search.close": "Cerrar busqueda",
+
   // Course reader
   "course.search.label": "Ingrese un termino de busqueda:",
   "course.search.button": "Buscar",

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -66,6 +66,14 @@ const fr: Record<string, string> = {
   "home.credits.description": "Tutors est un projet open source disponible gratuitement sous licence MIT sur GitHub.",
   "home.credits.viewSource": "Voir le code source",
 
+  // Search overlay
+  "search.placeholder": "Rechercher dans ce cours...",
+  "search.noResults": "Aucun resultat trouve",
+  "search.shortcut": "pour rechercher",
+  "search.navigate": "pour naviguer",
+  "search.select": "pour selectionner",
+  "search.close": "Fermer la recherche",
+
   // Course reader
   "course.search.label": "Entrez un terme de recherche :",
   "course.search.button": "Rechercher",

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -66,6 +66,14 @@ const it: Record<string, string> = {
   "home.credits.description": "Tutors e un progetto open source disponibile gratuitamente su GitHub con licenza MIT.",
   "home.credits.viewSource": "Visualizza il codice sorgente",
 
+  // Search overlay
+  "search.placeholder": "Cerca in questo corso...",
+  "search.noResults": "Nessun risultato trovato",
+  "search.shortcut": "per cercare",
+  "search.navigate": "per navigare",
+  "search.select": "per selezionare",
+  "search.close": "Chiudi ricerca",
+
   // Course reader
   "course.search.label": "Inserisci un termine di ricerca:",
   "course.search.button": "Cerca",

--- a/src/lib/services/search/index.ts
+++ b/src/lib/services/search/index.ts
@@ -1,0 +1,2 @@
+export { searchService } from "./search-service.svelte";
+export type { SearchDocument, SearchResult } from "./types";

--- a/src/lib/services/search/search-service.svelte.ts
+++ b/src/lib/services/search/search-service.svelte.ts
@@ -1,0 +1,135 @@
+import MiniSearch from "minisearch";
+import { flattenLos } from "@tutors/tutors-model-lib";
+import type { Course, Lo, Lab } from "@tutors/tutors-model-lib";
+import type { SearchDocument, SearchResult } from "./types";
+
+const INDEXABLE_TYPES = new Set(["note", "lab", "panelnote", "tutorial", "notebook", "topic"]);
+const TITLE_ONLY_TYPES = new Set(["topic"]);
+
+function stripMarkdown(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/!\[.*?\]\(.*?\)/g, "")
+    .replace(/\[([^\]]+)\]\(.*?\)/g, "$1")
+    .replace(/[*_~`]/g, "")
+    .trim();
+}
+
+function buildDocuments(course: Course): SearchDocument[] {
+  const allLos = flattenLos(course.los);
+  const documents: SearchDocument[] = [];
+  const seenIds = new Set<string>();
+
+  for (const lo of allLos) {
+    if (lo.hide || !INDEXABLE_TYPES.has(lo.type)) continue;
+    if (!lo.route || seenIds.has(lo.route)) continue;
+    seenIds.add(lo.route);
+
+    const content = TITLE_ONLY_TYPES.has(lo.type) ? "" : stripMarkdown(lo.contentMd ?? "");
+
+    documents.push({
+      id: lo.route,
+      type: lo.type,
+      title: lo.title ?? "",
+      summary: lo.summary ?? "",
+      content,
+      route: lo.route,
+      parentTitle: lo.parentLo?.title ?? "",
+      topicTitle: lo.parentTopic?.title ?? lo.parentLo?.title ?? ""
+    });
+
+    if (lo.type === "lab") {
+      const lab = lo as Lab;
+      if (lab.los) {
+        for (const step of lab.los) {
+          const stepRoute = step.route ?? `${lo.route}/${step.id}`;
+          if (seenIds.has(stepRoute)) continue;
+          seenIds.add(stepRoute);
+
+          documents.push({
+            id: stepRoute,
+            type: "step",
+            title: step.title ?? "",
+            summary: "",
+            content: stripMarkdown(step.contentMd ?? ""),
+            route: stepRoute,
+            parentTitle: lo.title,
+            topicTitle: lo.parentTopic?.title ?? lo.parentLo?.title ?? ""
+          });
+        }
+      }
+    }
+  }
+
+  return documents;
+}
+
+function createSearchService() {
+  const indices = new Map<string, MiniSearch<SearchDocument>>();
+  const loMaps = new Map<string, Map<string, Lo>>();
+
+  return {
+    buildIndex(course: Course): void {
+      if (indices.has(course.courseId)) return;
+
+      const documents = buildDocuments(course);
+      const miniSearch = new MiniSearch<SearchDocument>({
+        fields: ["title", "summary", "content"],
+        storeFields: ["type", "title", "route", "parentTitle", "topicTitle"],
+        searchOptions: {
+          boost: { title: 3, summary: 2, content: 1 },
+          fuzzy: 0.2,
+          prefix: true
+        }
+      });
+      miniSearch.addAll(documents);
+      indices.set(course.courseId, miniSearch);
+
+      const loMap = new Map<string, Lo>();
+      const allLos = flattenLos(course.los);
+      for (const lo of allLos) {
+        loMap.set(lo.route, lo);
+        if (lo.type === "lab") {
+          const lab = lo as Lab;
+          if (lab.los) {
+            for (const step of lab.los) {
+              if (step.route) loMap.set(step.route, step as unknown as Lo);
+            }
+          }
+        }
+      }
+      loMaps.set(course.courseId, loMap);
+    },
+
+    search(courseId: string, query: string): SearchResult[] {
+      const index = indices.get(courseId);
+      const loMap = loMaps.get(courseId);
+      if (!index || !loMap || !query.trim()) return [];
+
+      const rawResults = index.search(query, {
+        fuzzy: 0.2,
+        prefix: true,
+        boost: { title: 3, summary: 2, content: 1 }
+      });
+
+      return rawResults.map((result) => ({
+        lo: loMap.get(result.id) ?? ({ title: result.title, route: result.id, type: result.type } as unknown as Lo),
+        score: result.score,
+        matchedFields: Object.keys(result.match)
+      }));
+    },
+
+    isIndexed(courseId: string): boolean {
+      return indices.has(courseId);
+    },
+
+    clearIndex(courseId: string): void {
+      indices.delete(courseId);
+      loMaps.delete(courseId);
+    }
+  };
+}
+
+export const searchService = createSearchService();

--- a/src/lib/services/search/types.ts
+++ b/src/lib/services/search/types.ts
@@ -1,0 +1,18 @@
+import type { Lo } from "@tutors/tutors-model-lib";
+
+export interface SearchDocument {
+  id: string;
+  type: string;
+  title: string;
+  summary: string;
+  content: string;
+  route: string;
+  parentTitle: string;
+  topicTitle: string;
+}
+
+export interface SearchResult {
+  lo: Lo;
+  score: number;
+  matchedFields: string[];
+}

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -2,7 +2,8 @@
   import Footer from "$lib/ui/navigators/footers/Footer.svelte";
   import { onMount, type Snippet } from "svelte";
   import MainNavigator from "./navigators/MainNavigator.svelte";
-  import { animationDelay, hideMainNavigator } from "$lib/runes.svelte";
+  import { animationDelay, currentCourse, hideMainNavigator, searchOpen } from "$lib/runes.svelte";
+  import SearchOverlay from "./components/SearchOverlay.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -15,7 +16,18 @@
   onMount(() => {
     showFooter = true;
   });
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      if (currentCourse.value && !currentCourse.value.isPortfolio) {
+        searchOpen.value = !searchOpen.value;
+      }
+    }
+  }
 </script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
 
 <div class="flex h-screen flex-col">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:z-50 focus:p-4 focus:bg-primary-500 focus:text-white">
@@ -43,6 +55,10 @@
     </footer>
   {/if}
 </div>
+
+{#if currentCourse?.value && !currentCourse?.value?.isPortfolio}
+  <SearchOverlay />
+{/if}
 
 <style>
 </style>

--- a/src/lib/ui/components/SearchOverlay.svelte
+++ b/src/lib/ui/components/SearchOverlay.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { searchService } from "$lib/services/search";
+  import type { SearchResult } from "$lib/services/search";
+  import { currentCourse, searchOpen } from "$lib/runes.svelte";
+  import Icon from "./Icon.svelte";
+  import { t } from "$lib/services/i18n";
+  import { browser } from "$app/environment";
+
+  let query = $state("");
+  let results = $state<SearchResult[]>([]);
+  let selectedIndex = $state(0);
+  let inputElement: HTMLInputElement | undefined = $state();
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  let resultsContainer: HTMLElement | undefined = $state();
+
+  const isMac = browser && navigator.platform.toUpperCase().includes("MAC");
+
+  function performSearch(value: string) {
+    query = value;
+    selectedIndex = 0;
+    clearTimeout(debounceTimer);
+    if (!value.trim()) {
+      results = [];
+      return;
+    }
+    debounceTimer = setTimeout(() => {
+      const courseId = currentCourse.value?.courseId;
+      if (courseId) {
+        results = searchService.search(courseId, value).slice(0, 20);
+      }
+    }, 150);
+  }
+
+  function navigateToResult(result: SearchResult) {
+    close();
+    goto(result.lo.route);
+  }
+
+  function close() {
+    searchOpen.value = false;
+    query = "";
+    results = [];
+    selectedIndex = 0;
+  }
+
+  function scrollSelectedIntoView() {
+    const item = resultsContainer?.children[selectedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, results.length - 1);
+      scrollSelectedIntoView();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+      scrollSelectedIntoView();
+    } else if (e.key === "Enter" && results[selectedIndex]) {
+      e.preventDefault();
+      navigateToResult(results[selectedIndex]);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  }
+
+  function typeLabel(type: string): string {
+    const labels: Record<string, string> = {
+      lab: "Lab",
+      step: "Step",
+      note: "Note",
+      panelnote: "Note",
+      tutorial: "Tutorial",
+      notebook: "Notebook",
+      topic: "Topic"
+    };
+    return labels[type] ?? type;
+  }
+
+  $effect(() => {
+    if (searchOpen.value && inputElement) {
+      setTimeout(() => inputElement?.focus(), 50);
+    }
+  });
+</script>
+
+{#if searchOpen.value}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="fixed inset-0 z-[9999] flex items-start justify-center pt-[15vh]" onkeydown={onKeydown}>
+    <button class="absolute inset-0 bg-black/50 backdrop-blur-sm" onclick={close} aria-label={t("search.close")} tabindex="-1"></button>
+
+    <div class="bg-surface-100 dark:bg-surface-900 relative z-10 mx-4 w-full max-w-xl overflow-hidden rounded-xl shadow-2xl" role="dialog" aria-modal="true" aria-label={t("nav.search.tip")}>
+      <div class="flex items-center gap-3 border-b border-surface-300 dark:border-surface-700 px-4 py-3">
+        <Icon type="search" />
+        <input
+          bind:this={inputElement}
+          type="text"
+          value={query}
+          oninput={(e) => performSearch(e.currentTarget.value)}
+          class="flex-1 bg-transparent text-base outline-none placeholder:text-surface-400"
+          placeholder={t("search.placeholder")}
+          role="combobox"
+          aria-expanded={results.length > 0}
+          aria-controls="search-results"
+          aria-activedescendant={results.length > 0 ? `search-result-${selectedIndex}` : undefined}
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <kbd class="hidden rounded bg-surface-200 dark:bg-surface-700 px-1.5 py-0.5 text-xs font-mono text-surface-500 sm:inline">esc</kbd>
+      </div>
+
+      {#if results.length > 0}
+        <ul id="search-results" class="max-h-80 overflow-y-auto p-2" role="listbox" bind:this={resultsContainer}>
+          {#each results as result, i}
+            <li
+              id="search-result-{i}"
+              role="option"
+              aria-selected={i === selectedIndex}
+              class="flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors {i === selectedIndex ? 'bg-surface-200 dark:bg-surface-700' : 'hover:bg-surface-200/50 dark:hover:bg-surface-700/50'}"
+              onclick={() => navigateToResult(result)}
+              onkeydown={(e) => e.key === "Enter" && navigateToResult(result)}
+              onmouseenter={() => (selectedIndex = i)}
+            >
+              <div class="flex-shrink-0">
+                <Icon type={result.lo.type === "step" ? "lab" : result.lo.type} height="18" />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-sm font-medium">{result.lo.title}</div>
+                {#if result.lo.parentLo?.title}
+                  <div class="truncate text-xs text-surface-500">{result.lo.parentLo.title}</div>
+                {/if}
+              </div>
+              <span class="flex-shrink-0 rounded bg-surface-200 dark:bg-surface-700 px-1.5 py-0.5 text-[10px] font-medium text-surface-500">
+                {typeLabel(result.lo.type)}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {:else if query.trim()}
+        <div class="px-4 py-8 text-center text-sm text-surface-500">
+          {t("search.noResults")}
+        </div>
+      {/if}
+
+      <div class="flex items-center gap-4 border-t border-surface-300 dark:border-surface-700 px-4 py-2 text-[11px] text-surface-400">
+        <span><kbd class="rounded bg-surface-200 dark:bg-surface-700 px-1 py-0.5 font-mono">↑↓</kbd> {t("search.navigate")}</span>
+        <span><kbd class="rounded bg-surface-200 dark:bg-surface-700 px-1 py-0.5 font-mono">↵</kbd> {t("search.select")}</span>
+        <span class="ml-auto"><kbd class="rounded bg-surface-200 dark:bg-surface-700 px-1 py-0.5 font-mono">{isMac ? "⌘" : "Ctrl"}+K</kbd> {t("search.shortcut")}</span>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/ui/navigators/buttons/SearchButton.svelte
+++ b/src/lib/ui/navigators/buttons/SearchButton.svelte
@@ -1,62 +1,12 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
-  import { onMount, onDestroy } from "svelte";
-  import { currentCourse } from "$lib/runes.svelte";
+  import { searchOpen } from "$lib/runes.svelte";
   import Icon from "$lib/ui/components/Icon.svelte";
   import { t } from "$lib/services/i18n";
-
-  let isSearching = $state(sessionStorage.getItem("isSearching") === "true");
-  let previousPage = "";
-  let observer: MutationObserver | null = null;
-
-  const updateSearchState = () => {
-    const currentPath = window.location.pathname;
-    isSearching = currentPath.includes("/search/");
-    sessionStorage.setItem("isSearching", isSearching.toString());
-  };
-
-  const toggleSearch = () => {
-    if (isSearching) {
-      goto(previousPage || "/course/" + currentCourse?.value?.courseId);
-      sessionStorage.removeItem("isSearching");
-    } else {
-      previousPage = window.location.pathname;
-      goto("/search/" + currentCourse?.value?.courseId);
-      sessionStorage.setItem("isSearching", "true");
-    }
-    isSearching = !isSearching;
-  };
-
-  const checkForNavigation = () => {
-    const currentPath = window.location.pathname;
-    if (!currentPath.includes("/search/") && isSearching) {
-      isSearching = false;
-      sessionStorage.removeItem("isSearching");
-    } else if (currentPath.includes("/search/")) {
-      isSearching = true;
-      sessionStorage.setItem("isSearching", "true");
-    }
-  };
-
-  onMount(() => {
-    observer = new MutationObserver(checkForNavigation);
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true
-    });
-    window.addEventListener("popstate", updateSearchState);
-    updateSearchState();
-  });
-
-  onDestroy(() => {
-    observer?.disconnect();
-    window.removeEventListener("popstate", updateSearchState);
-  });
 </script>
 
-<button onclick={toggleSearch}>
+<button onclick={() => (searchOpen.value = true)} aria-label={t("nav.search.tip")}>
   <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
     <Icon type="search" tip={t("nav.search.tip")} />
-    <span class="hidden lg:block"> {isSearching ? t("nav.search.exit") : t("nav.search")}</span>
+    <span class="hidden lg:block">{t("nav.search")}</span>
   </div>
 </button>

--- a/src/routes/(course-reader)/search/[courseid]/+page.svelte
+++ b/src/routes/(course-reader)/search/[courseid]/+page.svelte
@@ -1,16 +1,8 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { onMount } from "svelte";
-  import type { ResultType } from "@tutors/tutors-model-lib";
-  import { isValid, searchHits, filterByType } from "@tutors/tutors-model-lib";
-  import type { Lo } from "@tutors/tutors-model-lib";
-  import type { Course } from "@tutors/tutors-model-lib";
-  import { convertMdToHtml } from "@tutors/tutors-model-lib";
+  import { searchOpen } from "$lib/runes.svelte";
   import type { PageData } from "./$types";
-  import { currentLo } from "$lib/runes.svelte";
-  import { currentCodeTheme } from "$lib/services/markdown";
-  import Icon from "$lib/ui/components/Icon.svelte";
-  import { t } from "$lib/services/i18n";
-  import { sanitizeHtml } from "$lib/utils/sanitize";
 
   interface Props {
     data: PageData;
@@ -18,94 +10,8 @@
 
   let { data }: Props = $props();
 
-  let course: Course;
-  let searchLos: Lo[] = [];
-  let searchTerm = $state("");
-  let searchResults: ResultType[] = $state([]);
-  let searchInputElement = $state();
-
-  onMount(async () => {
-    course = data.course;
-    currentLo.value = data.course;
-    const labs = filterByType(data.course.los, "lab");
-    labs.forEach((lab) => {
-      lab?.los?.forEach((step) => {
-        step.parentLo = lab;
-      });
-    });
-    const steps = filterByType(data.course.los, "step");
-    const notes = filterByType(data.course.los, "note");
-    const panelNotes = filterByType(data.course.los, "panelnote");
-    searchLos.push(...labs, ...steps, ...notes, ...panelNotes);
-    searchInputElement.focus();
+  onMount(() => {
+    searchOpen.value = true;
+    goto(`/course/${data.course.courseId}`, { replaceState: true });
   });
-
-  function transformResults(results: ResultType[]) {
-    results.forEach((result) => {
-      let resultStrs: string[] = [];
-      if (result.fenced) {
-        resultStrs.push(`~~~${result.language}`);
-      }
-      resultStrs.push(result.contentMd);
-      if (result.fenced) {
-        resultStrs.push("~~~");
-      }
-      result.html = convertMdToHtml(resultStrs.join("\n"), currentCodeTheme.value);
-      result.link = `/${result.link}`;
-    });
-  }
-
-  let lastSearchTerm = "";
-
-  function performSearch() {
-    if (isValid(searchTerm) && searchTerm !== lastSearchTerm) {
-      lastSearchTerm = searchTerm;
-      searchResults = searchHits(searchLos, searchTerm);
-      transformResults(searchResults);
-    }
-  }
-
-  // $effect(() => {
-  //   if (isValid(searchTerm) && searchTerm !== lastSearchTerm) {
-  //     lastSearchTerm = searchTerm;
-  //     searchResults = searchHits(searchLos, searchTerm);
-  //     transformResults(searchResults);
-  //   }
-  // });
 </script>
-
-<div class="card container mx-auto mb-4 p-4">
-  <label for="search" class="label"><span>{t("course.search.label")}</span></label>
-  <div class="flex items-center gap-2">
-    <button onclick={performSearch} class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
-      <Icon type="search" tip={t("nav.search.tip")} />
-      <span class="hidden lg:block">{t("course.search.button")}</span>
-    </button>
-    <input
-      bind:value={searchTerm}
-      bind:this={searchInputElement}
-      type="text"
-      name="search"
-      id="search"
-      class="input flex-1 p-2"
-      placeholder="..."
-      onkeydown={(e) => e.key === "Enter" && performSearch()}
-    />
-  </div>
-  <div class="mt-2 flex flex-wrap justify-center">
-    {#each searchResults as result}
-      <div class="card m-1 w-full border p-4">
-        <div>
-          <div class="prose dark:prose-invert">
-            {@html sanitizeHtml(result.html ?? "")}
-          </div>
-          <div class="pt-4 text-right text-sm">
-            <a rel="noopener noreferrer" href={result.link} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300">
-              {result.title}
-            </a>
-          </div>
-        </div>
-      </div>
-    {/each}
-  </div>
-</div>


### PR DESCRIPTION
## Summary
- Replace the old full-page substring search with an instant **Cmd/Ctrl+K command palette overlay** powered by [MiniSearch](https://github.com/lucaong/minisearch) (~7kb gzipped)
- Search index is built eagerly when a course loads, covering **notes, labs, lab steps, tutorials, notebooks, and topics** — excludes PDFs (talks/paneltalks) to encourage plain text content
- Fuzzy matching, prefix search, and field boosting (title 3x, summary 2x, content 1x) for relevance-ranked results
- Keyboard navigation (↑↓ to browse, Enter to select, Escape to close)
- SearchButton simplified from 63 lines to 12 — removed MutationObserver, sessionStorage, and popstate hacks
- Legacy `/search/[courseid]` route redirects to the overlay
- i18n keys added across all 5 languages (en, fr, de, it, es)

## Test plan
- [ ] Load a course, press Ctrl+K (or Cmd+K on Mac) — overlay opens with focus on input
- [ ] Type a search term — results appear instantly, ranked by relevance
- [ ] Arrow keys navigate results, Enter navigates to the content, Escape closes
- [ ] Click the Search button in the nav bar — opens overlay (same as Cmd+K)
- [ ] Verify talks/paneltalks (PDFs) do NOT appear in results
- [ ] Verify labs, notes, lab steps, tutorials, notebooks, topics DO appear in results
- [ ] Navigate to `/search/[courseid]` directly — redirects to course page with overlay open
- [ ] Test fuzzy matching — slight typos still return relevant results

🤖 Generated with [Claude Code](https://claude.com/claude-code)