### PR TITLE
Add guided onboarding tour for new users

### DIFF
--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -138,7 +138,30 @@ const de: Record<string, string> = {
   "a11y.breadcrumbs": "Brotkruemelnavigation",
   "a11y.secondaryNavigation": "Sekundaere Navigation",
   "a11y.sidebar": "Seitenleiste",
-  "a11y.footer": "Seitenfuss"
+  "a11y.footer": "Seitenfuss",
+
+  // Guided tour
+  "tour.ariaLabel": "Gefuehrte Tour",
+  "tour.skip": "Ueberspringen",
+  "tour.prev": "Zurueck",
+  "tour.next": "Weiter",
+  "tour.finish": "Fertig",
+  "tour.menuLabel": "Gefuehrte Tour",
+  "tour.startButton": "Tour starten",
+  "tour.courseTitle.title": "Kurstitel",
+  "tour.courseTitle.description": "Hier werden der Name und das Bild des aktuell angezeigten Kurses angezeigt.",
+  "tour.search.title": "Suche",
+  "tour.search.description": "Finden Sie schnell Inhalte in diesem Kurs. Sie koennen auch jederzeit Strg+K (oder Cmd+K auf dem Mac) druecken.",
+  "tour.layout.title": "Design und Layout",
+  "tour.layout.description": "Passen Sie das Erscheinungsbild an: Wechseln Sie zwischen hellem und dunklem Modus, aendern Sie den Kartenstil, das Design und die Sprache.",
+  "tour.profile.title": "Ihr Profil",
+  "tour.profile.description": "Melden Sie sich mit GitHub an, um Ihren Fortschritt zu verfolgen und Live-Praesenzfunktionen zu aktivieren.",
+  "tour.toc.title": "Kursbaum",
+  "tour.toc.description": "Oeffnen Sie den vollstaendigen Kursbaum, um alle Themen zu sehen und direkt zu einem Abschnitt zu navigieren.",
+  "tour.calendar.title": "Kalender",
+  "tour.calendar.description": "Sehen Sie den Kursplan und was diese Woche ansteht.",
+  "tour.info.title": "Kursinformationen",
+  "tour.info.description": "Lesen Sie detaillierte Informationen ueber diesen Kurs, einschliesslich seiner Beschreibung und Ziele."
 };
 
 export default de;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -150,7 +150,30 @@ Tutors is an open source application - the data collection component [is here](h
   "a11y.breadcrumbs": "Breadcrumbs",
   "a11y.secondaryNavigation": "Secondary navigation",
   "a11y.sidebar": "Sidebar",
-  "a11y.footer": "Site footer"
+  "a11y.footer": "Site footer",
+
+  // Guided tour
+  "tour.ariaLabel": "Guided tour",
+  "tour.skip": "Skip",
+  "tour.prev": "Back",
+  "tour.next": "Next",
+  "tour.finish": "Done",
+  "tour.menuLabel": "Guided Tour",
+  "tour.startButton": "Start Tour",
+  "tour.courseTitle.title": "Course Title",
+  "tour.courseTitle.description": "This shows the name and image of the course you are currently viewing.",
+  "tour.search.title": "Search",
+  "tour.search.description": "Quickly find content in this course. You can also press Ctrl+K (or Cmd+K on Mac) anytime.",
+  "tour.layout.title": "Theme & Layout",
+  "tour.layout.description": "Customize the appearance: switch between light and dark mode, change the card style, theme, and language.",
+  "tour.profile.title": "Your Profile",
+  "tour.profile.description": "Sign in with GitHub to track your progress and enable live presence features.",
+  "tour.toc.title": "Course Tree",
+  "tour.toc.description": "Open the full course tree to see all topics and navigate directly to any section.",
+  "tour.calendar.title": "Calendar",
+  "tour.calendar.description": "View the course schedule and see what is coming up this week.",
+  "tour.info.title": "Course Info",
+  "tour.info.description": "Read detailed information about this course, including its description and objectives."
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -138,7 +138,30 @@ const es: Record<string, string> = {
   "a11y.breadcrumbs": "Migas de pan",
   "a11y.secondaryNavigation": "Navegacion secundaria",
   "a11y.sidebar": "Barra lateral",
-  "a11y.footer": "Pie de pagina"
+  "a11y.footer": "Pie de pagina",
+
+  // Guided tour
+  "tour.ariaLabel": "Tour guiado",
+  "tour.skip": "Saltar",
+  "tour.prev": "Atras",
+  "tour.next": "Siguiente",
+  "tour.finish": "Listo",
+  "tour.menuLabel": "Tour guiado",
+  "tour.startButton": "Iniciar tour",
+  "tour.courseTitle.title": "Titulo del curso",
+  "tour.courseTitle.description": "Aqui se muestra el nombre y la imagen del curso que estas viendo actualmente.",
+  "tour.search.title": "Buscar",
+  "tour.search.description": "Encuentra rapidamente contenido en este curso. Tambien puedes presionar Ctrl+K (o Cmd+K en Mac) en cualquier momento.",
+  "tour.layout.title": "Tema y diseno",
+  "tour.layout.description": "Personaliza la apariencia: alterna entre modo claro y oscuro, cambia el estilo de las tarjetas, el tema y el idioma.",
+  "tour.profile.title": "Tu perfil",
+  "tour.profile.description": "Inicia sesion con GitHub para seguir tu progreso y activar las funciones de presencia en vivo.",
+  "tour.toc.title": "Arbol del curso",
+  "tour.toc.description": "Abre el arbol completo del curso para ver todos los temas y navegar directamente a cualquier seccion.",
+  "tour.calendar.title": "Calendario",
+  "tour.calendar.description": "Consulta el horario del curso y mira lo que viene esta semana.",
+  "tour.info.title": "Informacion del curso",
+  "tour.info.description": "Lee informacion detallada sobre este curso, incluyendo su descripcion y objetivos."
 };
 
 export default es;

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -138,7 +138,30 @@ const fr: Record<string, string> = {
   "a11y.breadcrumbs": "Fil d'Ariane",
   "a11y.secondaryNavigation": "Navigation secondaire",
   "a11y.sidebar": "Barre laterale",
-  "a11y.footer": "Pied de page"
+  "a11y.footer": "Pied de page",
+
+  // Guided tour
+  "tour.ariaLabel": "Visite guidee",
+  "tour.skip": "Passer",
+  "tour.prev": "Retour",
+  "tour.next": "Suivant",
+  "tour.finish": "Terminer",
+  "tour.menuLabel": "Visite guidee",
+  "tour.startButton": "Commencer la visite",
+  "tour.courseTitle.title": "Titre du cours",
+  "tour.courseTitle.description": "Ceci affiche le nom et l'image du cours que vous consultez actuellement.",
+  "tour.search.title": "Recherche",
+  "tour.search.description": "Trouvez rapidement du contenu dans ce cours. Vous pouvez aussi appuyer sur Ctrl+K (ou Cmd+K sur Mac) a tout moment.",
+  "tour.layout.title": "Theme et mise en page",
+  "tour.layout.description": "Personnalisez l'apparence : basculez entre le mode clair et sombre, changez le style des cartes, le theme et la langue.",
+  "tour.profile.title": "Votre profil",
+  "tour.profile.description": "Connectez-vous avec GitHub pour suivre votre progression et activer les fonctionnalites de presence en direct.",
+  "tour.toc.title": "Arborescence du cours",
+  "tour.toc.description": "Ouvrez l'arborescence complete du cours pour voir tous les sujets et naviguer directement vers n'importe quelle section.",
+  "tour.calendar.title": "Calendrier",
+  "tour.calendar.description": "Consultez le calendrier du cours et voyez ce qui est prevu cette semaine.",
+  "tour.info.title": "Informations sur le cours",
+  "tour.info.description": "Lisez les informations detaillees sur ce cours, y compris sa description et ses objectifs."
 };
 
 export default fr;

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -138,7 +138,30 @@ const it: Record<string, string> = {
   "a11y.breadcrumbs": "Breadcrumb",
   "a11y.secondaryNavigation": "Navigazione secondaria",
   "a11y.sidebar": "Barra laterale",
-  "a11y.footer": "Pie di pagina"
+  "a11y.footer": "Pie di pagina",
+
+  // Guided tour
+  "tour.ariaLabel": "Tour guidato",
+  "tour.skip": "Salta",
+  "tour.prev": "Indietro",
+  "tour.next": "Avanti",
+  "tour.finish": "Fine",
+  "tour.menuLabel": "Tour guidato",
+  "tour.startButton": "Inizia il tour",
+  "tour.courseTitle.title": "Titolo del corso",
+  "tour.courseTitle.description": "Qui viene mostrato il nome e l'immagine del corso che stai visualizzando.",
+  "tour.search.title": "Cerca",
+  "tour.search.description": "Trova rapidamente i contenuti in questo corso. Puoi anche premere Ctrl+K (o Cmd+K su Mac) in qualsiasi momento.",
+  "tour.layout.title": "Tema e layout",
+  "tour.layout.description": "Personalizza l'aspetto: passa dalla modalita chiara a quella scura, cambia lo stile delle schede, il tema e la lingua.",
+  "tour.profile.title": "Il tuo profilo",
+  "tour.profile.description": "Accedi con GitHub per monitorare i tuoi progressi e attivare le funzionalita di presenza in tempo reale.",
+  "tour.toc.title": "Albero del corso",
+  "tour.toc.description": "Apri l'albero completo del corso per vedere tutti gli argomenti e navigare direttamente a qualsiasi sezione.",
+  "tour.calendar.title": "Calendario",
+  "tour.calendar.description": "Visualizza il programma del corso e scopri cosa e previsto per questa settimana.",
+  "tour.info.title": "Informazioni sul corso",
+  "tour.info.description": "Leggi informazioni dettagliate su questo corso, inclusa la descrizione e gli obiettivi."
 };
 
 export default it;

--- a/src/lib/services/tour/index.ts
+++ b/src/lib/services/tour/index.ts
@@ -1,0 +1,2 @@
+export { tourService } from "./tour-service.svelte";
+export type { TourStep, TourPlacement } from "./types";

--- a/src/lib/services/tour/steps.ts
+++ b/src/lib/services/tour/steps.ts
@@ -1,0 +1,49 @@
+import type { TourStep } from "./types";
+
+export const courseReaderSteps: TourStep[] = [
+  {
+    target: "[data-tour='course-title']",
+    titleKey: "tour.courseTitle.title",
+    descriptionKey: "tour.courseTitle.description",
+    placement: "bottom"
+  },
+  {
+    target: "[data-tour='search']",
+    titleKey: "tour.search.title",
+    descriptionKey: "tour.search.description",
+    placement: "bottom"
+  },
+  {
+    target: "[data-tour='layout']",
+    titleKey: "tour.layout.title",
+    descriptionKey: "tour.layout.description",
+    placement: "bottom"
+  },
+  {
+    target: "[data-tour='profile']",
+    titleKey: "tour.profile.title",
+    descriptionKey: "tour.profile.description",
+    placement: "bottom"
+  },
+  {
+    target: "[data-tour='toc']",
+    titleKey: "tour.toc.title",
+    descriptionKey: "tour.toc.description",
+    placement: "left",
+    optional: true
+  },
+  {
+    target: "[data-tour='calendar']",
+    titleKey: "tour.calendar.title",
+    descriptionKey: "tour.calendar.description",
+    placement: "bottom",
+    optional: true
+  },
+  {
+    target: "[data-tour='info']",
+    titleKey: "tour.info.title",
+    descriptionKey: "tour.info.description",
+    placement: "right",
+    optional: true
+  }
+];

--- a/src/lib/services/tour/tour-service.svelte.ts
+++ b/src/lib/services/tour/tour-service.svelte.ts
@@ -1,0 +1,95 @@
+import { rune } from "$lib/runes.svelte";
+import type { TourStep } from "./types";
+import { courseReaderSteps } from "./steps";
+import { browser } from "$app/environment";
+
+const TOUR_COMPLETED_KEY = "tutors-tour-completed";
+
+function createTourService() {
+  const isOpen = rune(false);
+  const currentStepIndex = rune(0);
+  const activeSteps = rune<TourStep[]>([]);
+
+  function isElementVisible(el: Element): boolean {
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function start(steps: TourStep[] = courseReaderSteps) {
+    if (!browser) return;
+    const visible = steps.filter((step) => {
+      const el = document.querySelector(step.target);
+      if (!el) return false;
+      if (step.optional && !isElementVisible(el)) return false;
+      return true;
+    });
+    if (visible.length === 0) return;
+    activeSteps.value = visible;
+    currentStepIndex.value = 0;
+    isOpen.value = true;
+  }
+
+  function next() {
+    if (currentStepIndex.value < activeSteps.value.length - 1) {
+      currentStepIndex.value++;
+    } else {
+      complete();
+    }
+  }
+
+  function prev() {
+    if (currentStepIndex.value > 0) {
+      currentStepIndex.value--;
+    }
+  }
+
+  function skip() {
+    isOpen.value = false;
+    currentStepIndex.value = 0;
+    activeSteps.value = [];
+  }
+
+  function complete() {
+    isOpen.value = false;
+    currentStepIndex.value = 0;
+    activeSteps.value = [];
+    if (browser) {
+      localStorage.setItem(TOUR_COMPLETED_KEY, "true");
+    }
+  }
+
+  return {
+    isOpen,
+    currentStepIndex,
+    activeSteps,
+
+    get currentStep(): TourStep | null {
+      return activeSteps.value[currentStepIndex.value] ?? null;
+    },
+
+    get totalSteps(): number {
+      return activeSteps.value.length;
+    },
+
+    get isFirstStep(): boolean {
+      return currentStepIndex.value === 0;
+    },
+
+    get isLastStep(): boolean {
+      return currentStepIndex.value === activeSteps.value.length - 1;
+    },
+
+    get hasCompleted(): boolean {
+      if (!browser) return false;
+      return localStorage.getItem(TOUR_COMPLETED_KEY) === "true";
+    },
+
+    start,
+    next,
+    prev,
+    skip,
+    complete
+  };
+}
+
+export const tourService = createTourService();

--- a/src/lib/services/tour/types.ts
+++ b/src/lib/services/tour/types.ts
@@ -1,0 +1,11 @@
+import type { MessageKey } from "$lib/services/i18n";
+
+export type TourPlacement = "top" | "bottom" | "left" | "right";
+
+export interface TourStep {
+  target: string;
+  titleKey: MessageKey;
+  descriptionKey: MessageKey;
+  placement: TourPlacement;
+  optional?: boolean;
+}

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -3,6 +3,7 @@
   import { onMount, type Snippet } from "svelte";
   import MainNavigator from "./navigators/MainNavigator.svelte";
   import { animationDelay, hideMainNavigator } from "$lib/runes.svelte";
+  import TourOverlay from "./components/TourOverlay.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -43,6 +44,8 @@
     </footer>
   {/if}
 </div>
+
+<TourOverlay />
 
 <style>
 </style>

--- a/src/lib/ui/components/TourOverlay.svelte
+++ b/src/lib/ui/components/TourOverlay.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import { tourService } from "$lib/services/tour";
+  import { t } from "$lib/services/i18n";
+  import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
+  import { browser } from "$app/environment";
+  import { afterNavigate } from "$app/navigation";
+  import type { TourPlacement } from "$lib/services/tour";
+
+  let targetRect = $state<DOMRect | null>(null);
+  let nextButton: HTMLButtonElement | undefined = $state();
+  let previousActiveElement: Element | null = null;
+
+  interface TooltipPos {
+    top: string;
+    left: string;
+  }
+
+  function computeTooltipPosition(rect: DOMRect, placement: TourPlacement): TooltipPos {
+    const gap = 12;
+    const tooltipWidth = 320;
+    const tooltipHeight = 160;
+    let top: number;
+    let left: number;
+
+    switch (placement) {
+      case "bottom":
+        top = rect.bottom + gap;
+        left = rect.left + rect.width / 2 - tooltipWidth / 2;
+        break;
+      case "top":
+        top = rect.top - tooltipHeight - gap;
+        left = rect.left + rect.width / 2 - tooltipWidth / 2;
+        break;
+      case "left":
+        top = rect.top + rect.height / 2 - tooltipHeight / 2;
+        left = rect.left - tooltipWidth - gap;
+        break;
+      case "right":
+        top = rect.top + rect.height / 2 - tooltipHeight / 2;
+        left = rect.right + gap;
+        break;
+    }
+
+    const pad = 16;
+    left = Math.max(pad, Math.min(left, window.innerWidth - tooltipWidth - pad));
+    top = Math.max(pad, Math.min(top, window.innerHeight - tooltipHeight - pad));
+
+    return { top: `${top}px`, left: `${left}px` };
+  }
+
+  function updateTargetRect() {
+    if (!tourService.isOpen.value || !browser) return;
+    const step = tourService.currentStep;
+    if (!step) return;
+    const el = document.querySelector(step.target);
+    if (el) {
+      targetRect = el.getBoundingClientRect();
+    } else {
+      targetRect = null;
+    }
+  }
+
+  $effect(() => {
+    if (!tourService.isOpen.value) return;
+    if (!previousActiveElement) {
+      previousActiveElement = document.activeElement;
+    }
+
+    const step = tourService.currentStep;
+    if (!step || !browser) return;
+
+    const el = document.querySelector(step.target);
+    if (el) {
+      el.scrollIntoView({ behavior: prefersReducedMotion.value ? "auto" : "smooth", block: "nearest" });
+      requestAnimationFrame(() => {
+        targetRect = el.getBoundingClientRect();
+        setTimeout(() => nextButton?.focus(), 50);
+      });
+    }
+
+    const onResize = () => updateTargetRect();
+    const onScroll = () => updateTargetRect();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onScroll, true);
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  });
+
+  $effect(() => {
+    if (!tourService.isOpen.value && previousActiveElement) {
+      (previousActiveElement as HTMLElement)?.focus?.();
+      previousActiveElement = null;
+    }
+  });
+
+  afterNavigate(() => {
+    if (tourService.isOpen.value) {
+      tourService.skip();
+    }
+  });
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      tourService.skip();
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      tourService.next();
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      tourService.prev();
+    }
+  }
+</script>
+
+{#if tourService.isOpen.value && targetRect && tourService.currentStep}
+  {@const step = tourService.currentStep}
+  {@const pos = computeTooltipPosition(targetRect, step.placement)}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-[9999]"
+    onkeydown={onKeydown}
+    role="dialog"
+    aria-modal="true"
+    aria-label={t("tour.ariaLabel")}
+    tabindex="-1"
+  >
+    <div
+      class="absolute rounded-lg pointer-events-none"
+      style="
+        top: {targetRect.top - 6}px;
+        left: {targetRect.left - 6}px;
+        width: {targetRect.width + 12}px;
+        height: {targetRect.height + 12}px;
+        box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+        transition: {prefersReducedMotion.value ? 'none' : 'all 0.3s ease'};
+      "
+    ></div>
+
+    <button
+      class="absolute inset-0 cursor-default"
+      onclick={() => tourService.skip()}
+      tabindex="-1"
+      aria-label={t("tour.skip")}
+    ></button>
+
+    <div
+      class="absolute z-10 w-80 rounded-xl bg-surface-100 dark:bg-surface-900 shadow-2xl"
+      style="top: {pos.top}; left: {pos.left}; transition: {prefersReducedMotion.value ? 'none' : 'top 0.3s ease, left 0.3s ease'};"
+    >
+      <div class="p-4">
+        <div role="status" aria-live="polite">
+          <h3 class="text-sm font-bold mb-1">{t(step.titleKey)}</h3>
+          <p class="text-sm text-surface-600 dark:text-surface-300 mb-4">{t(step.descriptionKey)}</p>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span class="text-xs text-surface-400">
+            {tourService.currentStepIndex.value + 1} / {tourService.totalSteps}
+          </span>
+          <div class="flex gap-2">
+            <button
+              class="rounded-lg px-3 py-1.5 text-xs font-medium text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700"
+              onclick={() => tourService.skip()}
+            >
+              {t("tour.skip")}
+            </button>
+            {#if !tourService.isFirstStep}
+              <button
+                class="rounded-lg px-3 py-1.5 text-xs font-medium text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700"
+                onclick={() => tourService.prev()}
+              >
+                {t("tour.prev")}
+              </button>
+            {/if}
+            <button
+              bind:this={nextButton}
+              class="rounded-lg bg-primary-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-600"
+              onclick={() => tourService.next()}
+            >
+              {tourService.isLastStep ? t("tour.finish") : t("tour.next")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/ui/navigators/LayoutMenu.svelte
+++ b/src/lib/ui/navigators/LayoutMenu.svelte
@@ -9,6 +9,7 @@
 
   import { Combobox, SegmentedControl, Portal } from "@skeletonlabs/skeleton-svelte";
   import { currentCourse } from "$lib/runes.svelte";
+  import { tourService } from "$lib/services/tour";
 
   interface ComboxData {
     label: string;
@@ -40,7 +41,7 @@
 </script>
 
 {#snippet menuSelector()}
-  <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center rounded-lg p-4">
+  <div data-tour="layout" class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center rounded-lg p-4">
     <Icon type="lightMode" tip={t("nav.layout.tip")} />
     <span class="ml-2 hidden text-sm font-bold md:block">{t("nav.layout")}</span>
   </div>
@@ -166,6 +167,19 @@
     <div class="mx-2 mb-2">
       <LanguageSwitcher />
     </div>
+    {#if currentCourse.value}
+      <hr />
+      <div class="mt-1 mb-1 ml-2">{t("tour.menuLabel")}</div>
+      <div class="mx-2 mb-2">
+        <button
+          class="preset-tonal w-full rounded-lg px-3 py-2 text-sm font-medium"
+          onclick={() => setTimeout(() => tourService.start(), 150)}
+        >
+          <Icon type="info" />
+          <span class="ml-1">{t("tour.startButton")}</span>
+        </button>
+      </div>
+    {/if}
   </div>
 {/snippet}
 

--- a/src/lib/ui/navigators/buttons/CalendarButton.svelte
+++ b/src/lib/ui/navigators/buttons/CalendarButton.svelte
@@ -8,7 +8,7 @@
 
 {#if currentCourse?.value?.courseCalendar?.currentWeek}
   {#snippet menuSelector()}
-    <div class="hidden w-full lg:flex">
+    <div data-tour="calendar" class="hidden w-full lg:flex">
       <button class="hover:preset-tonal mx-auto inline-flex rounded-lg p-2">
         <span class="my-auto pr-4 pl-2">
           <Icon tip={t("nav.calendar.tip")} type="calendar" />

--- a/src/lib/ui/navigators/buttons/InfoButton.svelte
+++ b/src/lib/ui/navigators/buttons/InfoButton.svelte
@@ -23,4 +23,6 @@
   </article>
 {/snippet}
 
-<Sidebar {menuSelector} {sidebarContent} />
+<div data-tour="info">
+  <Sidebar {menuSelector} {sidebarContent} />
+</div>

--- a/src/lib/ui/navigators/buttons/SearchButton.svelte
+++ b/src/lib/ui/navigators/buttons/SearchButton.svelte
@@ -54,7 +54,7 @@
   });
 </script>
 
-<button onclick={toggleSearch}>
+<button data-tour="search" onclick={toggleSearch}>
   <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
     <Icon type="search" tip={t("nav.search.tip")} />
     <span class="hidden lg:block"> {isSearching ? t("nav.search.exit") : t("nav.search")}</span>

--- a/src/lib/ui/navigators/buttons/TocButton.svelte
+++ b/src/lib/ui/navigators/buttons/TocButton.svelte
@@ -21,4 +21,6 @@
   </article>
 {/snippet}
 
-<Sidebar position="right" {menuSelector} {sidebarContent} />
+<div data-tour="toc">
+  <Sidebar position="right" {menuSelector} {sidebarContent} />
+</div>

--- a/src/lib/ui/navigators/titles/CourseTitle.svelte
+++ b/src/lib/ui/navigators/titles/CourseTitle.svelte
@@ -5,7 +5,7 @@
 </script>
 
 {#if currentLo?.value}
-  <div class="flex flex-nowrap items-center">
+  <div data-tour="course-title" class="flex flex-nowrap items-center">
     <div class="mr-2 inline-flex">
       {#if currentLo?.value?.img}
         <Image lo={currentLo?.value} miniImage={true} />

--- a/src/lib/ui/navigators/tutors-connect/AnonProfile.svelte
+++ b/src/lib/ui/navigators/tutors-connect/AnonProfile.svelte
@@ -27,4 +27,6 @@
   </ul>
 {/snippet}
 
-<Menu {menuSelector} {menuContent} />
+<div data-tour="profile">
+  <Menu {menuSelector} {menuContent} />
+</div>

--- a/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
+++ b/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
@@ -66,4 +66,6 @@
   </ul>
 {/snippet}
 
-<Menu {menuSelector} {menuContent} />
+<div data-tour="profile">
+  <Menu {menuSelector} {menuContent} />
+</div>


### PR DESCRIPTION
## Summary
- Adds a user-triggered guided tour that highlights key UI elements with a spotlight overlay and step-by-step tooltips
- Tour is accessible from the Layout menu ("Start Tour" button) on any course page
- Supports keyboard navigation (ArrowLeft/Right, Escape), reduced motion, focus management, and screen reader announcements
- Fully internationalized across all 5 locales (en, fr, de, it, es)

## Tour Steps
1. **Course Title** — orientation on the current course
2. **Search** — find content, mentions Ctrl/Cmd+K shortcut
3. **Theme & Layout** — customize appearance, dark mode, card style
4. **Profile** — sign in with GitHub for dashboard and presence
5. **Course Tree** — browse the full topic hierarchy (optional, hidden on mobile)
6. **Calendar** — view course schedule (optional, only when calendar exists)
7. **Info** — read course description (optional, hidden on mobile)

## Implementation
- Custom lightweight tour — no external library, follows the existing SearchOverlay pattern
- `src/lib/services/tour/` — rune-based tour service with step filtering for hidden/optional elements
- `src/lib/ui/components/TourOverlay.svelte` — spotlight via box-shadow cutout, positioned tooltip
- `data-tour` attributes added to 8 navigator components for targeting
- Tour completion saved to localStorage

## Test plan
- [ ] Load any course page → Layout menu → scroll to bottom → click "Start Tour"
- [ ] Click Next through all steps — spotlight and tooltip reposition correctly
- [ ] Click Back to return to previous steps
- [ ] Press Escape or Skip to dismiss the tour early
- [ ] Use ArrowRight/ArrowLeft keys to navigate
- [ ] Resize window during tour — spotlight should track target elements
- [ ] Test on mobile viewport — hidden elements (TOC, Calendar) should be skipped
- [ ] Toggle dark mode before tour — overlay and tooltip render correctly in both modes
- [ ] Switch language before tour — all tour text appears in the selected locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)