### PR TITLE
Improve ARIA accessibility across UI components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@auth/core": "^0.41.2",
         "@auth/sveltekit": "1.11.2",
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.5.0",
@@ -177,6 +178,19 @@
         }
       }
     },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -208,6 +222,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -899,35 +914,13 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2028,6 +2021,7 @@
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2268,6 +2262,7 @@
       "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-3.2.2.tgz",
       "integrity": "sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "cssesc": "^3.0.0",
@@ -2456,9 +2451,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,9 +2472,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,9 +2493,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2514,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,9 +2535,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2781,9 +2761,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2801,9 +2778,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2795,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2812,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2829,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,9 +2846,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2863,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2880,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3136,9 +3092,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3153,9 +3106,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3170,9 +3120,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3187,9 +3134,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,9 +3148,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3221,9 +3162,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3238,9 +3176,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3255,9 +3190,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3485,9 +3417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3505,9 +3434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,9 +3451,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3545,9 +3468,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3565,9 +3485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3585,9 +3502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3800,9 +3714,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3817,9 +3728,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3834,9 +3742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3851,9 +3756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3868,9 +3770,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3885,9 +3784,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3902,9 +3798,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3919,9 +3812,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3936,9 +3826,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3953,9 +3840,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3970,9 +3854,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3987,9 +3868,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4004,9 +3882,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5040,6 +4915,7 @@
       "integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -5099,6 +4975,7 @@
       "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "magic-string": "^0.30.21",
@@ -5269,9 +5146,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5289,9 +5163,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5309,9 +5180,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5329,9 +5197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5934,6 +5799,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5961,6 +5827,7 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6040,6 +5907,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -6147,6 +6015,7 @@
       "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6248,6 +6117,7 @@
       "integrity": "sha512-gIzazUkbQfv6T1rJHOLhMMKQnplKAvvQ7QNGaFwI6oCsp4z2aSDZCojGpX3QX3+MYsvJdyy/8BRIYVEbAkMkEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -6418,6 +6288,7 @@
       "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
@@ -7075,6 +6946,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7203,6 +7075,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -7282,6 +7164,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7743,6 +7626,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8164,6 +8048,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8525,6 +8410,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8589,6 +8475,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9363,6 +9250,7 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -10171,9 +10059,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10195,9 +10080,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10219,9 +10101,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10243,9 +10122,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10719,6 +10595,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -11713,6 +11590,7 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -11770,6 +11648,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11895,6 +11774,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11977,6 +11857,7 @@
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12008,6 +11889,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12024,6 +11906,7 @@
       "integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -12990,6 +12873,7 @@
       "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -13148,7 +13032,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -13417,6 +13302,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13671,6 +13557,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13867,6 +13754,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:integration": "vitest run tests/integration",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:a11y": "playwright test tests/e2e/accessibility.spec.ts",
+    "test:a11y": "playwright test --config=playwright-a11y.config.ts",
     "test:watch": "vitest",
     "test:changed": "vitest related --run",
     "test:mutation": "stryker run",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:integration": "vitest run tests/integration",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:a11y": "playwright test tests/e2e/accessibility.spec.ts",
     "test:watch": "vitest",
     "test:changed": "vitest related --run",
     "test:mutation": "stryker run",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@auth/core": "^0.41.2",
     "@auth/sveltekit": "1.11.2",
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
     "@faker-js/faker": "^10.5.0",

--- a/playwright-a11y.config.ts
+++ b/playwright-a11y.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: 'accessibility.spec.ts',
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -39,6 +39,7 @@ const de: Record<string, string> = {
   "menu.dashboard": "Dashboard",
   "menu.githubProfile": "Github-Profil",
   "menu.disconnect": "Trennen",
+  "menu.profile": "Profilmenü",
 
   // Home page
   "home.title": "Tutors:",

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -39,6 +39,7 @@ const en = {
   "menu.dashboard": "Dashboard",
   "menu.githubProfile": "Github Profile",
   "menu.disconnect": "Disconnect",
+  "menu.profile": "Profile menu",
 
   // Home page
   "home.title": "Tutors:",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -39,6 +39,7 @@ const es: Record<string, string> = {
   "menu.dashboard": "Panel de control",
   "menu.githubProfile": "Perfil de Github",
   "menu.disconnect": "Desconectar",
+  "menu.profile": "Menú de perfil",
 
   // Home page
   "home.title": "Tutors:",

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -39,6 +39,7 @@ const fr: Record<string, string> = {
   "menu.dashboard": "Tableau de bord",
   "menu.githubProfile": "Profil Github",
   "menu.disconnect": "Se deconnecter",
+  "menu.profile": "Menu du profil",
 
   // Home page
   "home.title": "Tutors :",

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -39,6 +39,7 @@ const it: Record<string, string> = {
   "menu.dashboard": "Dashboard",
   "menu.githubProfile": "Profilo Github",
   "menu.disconnect": "Disconnetti",
+  "menu.profile": "Menu del profilo",
 
   // Home page
   "home.title": "Tutors:",

--- a/src/lib/ui/components/Icon.svelte
+++ b/src/lib/ui/components/Icon.svelte
@@ -57,11 +57,15 @@
   {/if}
 {/snippet}
 
+{#snippet tooltipTrigger(attrs)}
+  <span {...attrs}>
+    {@render displayIcon()}
+  </span>
+{/snippet}
+
 {#if tip}
   <Tooltip>
-    <Tooltip.Trigger>
-      {@render displayIcon()}
-    </Tooltip.Trigger>
+    <Tooltip.Trigger element={tooltipTrigger} />
     <Portal>
       <Tooltip.Positioner>
         <Tooltip.Content class="card bg-surface-100-900 z-9999 max-w-md p-2 shadow-xl">

--- a/src/lib/ui/components/Icon.svelte
+++ b/src/lib/ui/components/Icon.svelte
@@ -13,9 +13,10 @@
     height?: string;
     tip?: string;
     text?: string;
+    ariaLabel?: string;
   }
 
-  let { type = "", icon = "", color = "", link = "", target = "", width = "", height = "20", tip = $bindable(""), text = "" }: Props = $props();
+  let { type = "", icon = "", color = "", link = "", target = "", width = "", height = "20", tip = $bindable(""), text = "", ariaLabel = "" }: Props = $props();
 
   if (target === "_blank") {
     tip = `${tip} (opens in a new Window)`;
@@ -40,17 +41,16 @@
 {#snippet displayIcon()}
   {#if type}
     {#if link}
-      <a class="btn btn-sm" {target} href={link}>
-        <Icon icon={themeService.getIcon(type).type} color={legacyIconColour(themeService.getIcon(type).color)} {width} {height} />
+      <a class="btn btn-sm" {target} href={link} aria-label={ariaLabel || tip || undefined} rel={target === "_blank" ? "noopener noreferrer" : undefined}>
+        <Icon icon={themeService.getIcon(type).type} color={legacyIconColour(themeService.getIcon(type).color)} {width} {height} aria-hidden="true" />
         {text}
       </a>
     {:else}
       <Icon icon={themeService.getIcon(type).type} color={legacyIconColour(themeService.getIcon(type).color)} {width} {height} />
     {/if}
   {:else if link}
-    <a {target} href={link}>
-      {color}
-      <Icon {icon} {color} {width} {height} />
+    <a {target} href={link} aria-label={ariaLabel || tip || undefined} rel={target === "_blank" ? "noopener noreferrer" : undefined}>
+      <Icon {icon} {color} {width} {height} aria-hidden="true" />
     </a>
   {:else}
     <Icon {icon} {color} {width} {height} />

--- a/src/lib/ui/components/Menu.svelte
+++ b/src/lib/ui/components/Menu.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Popover, Portal } from "@skeletonlabs/skeleton-svelte";
-  let { menuSelector, menuContent } = $props();
+  let { menuSelector, menuContent, ariaLabel = "" } = $props();
 </script>
 
 <Popover>
-  <Popover.Trigger>{@render menuSelector()}</Popover.Trigger>
+  <Popover.Trigger aria-label={ariaLabel || undefined}>{@render menuSelector()}</Popover.Trigger>
   <Portal>
     <Popover.Positioner>
       <Popover.Content class="card  bg-surface-50 z-999 m-4 max-w-[500px] space-y-4">

--- a/src/lib/ui/components/Sidebar.svelte
+++ b/src/lib/ui/components/Sidebar.svelte
@@ -23,7 +23,7 @@
         class={`card bg-surface-100-900 overflow-y-scroll h-screen w-sm space-y-4 p-4 opacity-0 shadow-xl transition transition-discrete ${contentTranslate} data-[state=open]:opacity-100 starting:data-[state=open]:opacity-0`}
       >
         <header class="flex items-center justify-end">
-          <Dialog.CloseTrigger class="btn-icon preset-tonal"><Icon type="close" /></Dialog.CloseTrigger>
+          <Dialog.CloseTrigger class="btn-icon preset-tonal" aria-label="Close"><Icon type="close" /></Dialog.CloseTrigger>
         </header>
         {@render sidebarContent()}
       </Dialog.Content>

--- a/src/lib/ui/components/Sidebar.svelte
+++ b/src/lib/ui/components/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { Dialog, Portal } from "@skeletonlabs/skeleton-svelte";
   import Icon from "./Icon.svelte";
 
-  let { position = "left", menuSelector, sidebarContent } = $props();
+  let { position = "left", menuSelector, sidebarContent, ariaLabel = "" } = $props();
 
   let positionerJustify = $state(position === "right" ? "justify-end" : "justify-start");
   let contentTranslate = $state(
@@ -13,7 +13,7 @@
 </script>
 
 <Dialog>
-  <Dialog.Trigger>
+  <Dialog.Trigger aria-label={ariaLabel || undefined}>
     {@render menuSelector()}
   </Dialog.Trigger>
   <Portal>

--- a/src/lib/ui/components/TutorsIcon.svelte
+++ b/src/lib/ui/components/TutorsIcon.svelte
@@ -5,7 +5,7 @@
   let { widthPlease = "40px" }: Props = $props();
 </script>
 
-<svg width={widthPlease} viewBox="0 0 54.5 39.4" xml:space="preserve">
+<svg width={widthPlease} viewBox="0 0 54.5 39.4" xml:space="preserve" role="img" aria-label="Tutors">
   <defs />
   <g>
     <path fill="#37919b" d="M51.5,0H3C1.4,0,0,1.4,0,3v33.3c0,1.7,1.4,3,3,3h48.5c1.7,0,3-1.4,3-3V3C54.5,1.4,53.1,0,51.5,0z M50,34.8H4.5 V4.5H50V34.8z" />

--- a/src/lib/ui/learning-objects/content/Calendar.svelte
+++ b/src/lib/ui/learning-objects/content/Calendar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Calendar } from "@tutors/tutors-model-lib";
+  import { t } from "$lib/services/i18n";
   const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
   interface Props {
@@ -9,18 +10,18 @@
 </script>
 
 <h4 class="mb-4 text-center font-semibold">{calendar.title}</h4>
-<table class="w-full table-auto">
+<table class="w-full table-auto" aria-label={calendar.title}>
   <thead>
     <tr>
-      <th class="mb-1 text-center">Week No.</th>
-      <th class="mb-1 text-center">Type</th>
-      <th class="mb-1 text-center">Date Starts</th>
+      <th scope="col" class="mb-1 text-center">{t("content.weekNo")}</th>
+      <th scope="col" class="mb-1 text-center">{t("content.type")}</th>
+      <th scope="col" class="mb-1 text-center">{t("content.dateStarts")}</th>
     </tr>
   </thead>
   <tbody class="text-center">
     {#each calendar.weeks as week}
       {#if calendar?.currentWeek?.title == week.title}
-        <tr class="bg-success-300 dark:bg-success-700 my-2">
+        <tr class="bg-success-300 dark:bg-success-700 my-2" aria-current="date">
           <td>{week.title}</td>
           <td>{week.type}</td>
           <td>{monthNames[week.dateObj.getMonth()]} {week.dateObj.getDate()}</td>

--- a/src/lib/ui/learning-objects/content/lab/Lab.svelte
+++ b/src/lib/ui/learning-objects/content/lab/Lab.svelte
@@ -65,7 +65,7 @@
         class="card bg-surface-100 border-primary-100 dark:border-primary-500 dark:bg-surface-950 sticky top-14 m-2 h-auto rounded-xl border-[1px]
           py-4"
       >
-        <nav class="nav-list">
+        <nav class="nav-list" aria-label="Lab steps">
           <ul>
             {@html sanitizeHtml(lab.navbarHtml ?? "")}
           </ul>
@@ -84,7 +84,7 @@
   </div>
 
   <div class="bg-primary-50 dark:bg-primary-900 fixed bottom-0 left-0 z-50 block w-full rounded-sm border lg:hidden">
-    <nav class="flex flex-wrap justify-between p-2">
+    <nav class="flex flex-wrap justify-between p-2" aria-label="Lab steps">
       {@html sanitizeHtml(lab.horizontalNavbarHtml ?? "")}
     </nav>
   </div>

--- a/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
@@ -6,6 +6,7 @@
   import { renderMarpSlides, buildMarpMarkdown } from "$lib/services/markdown/services/marp-renderer";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import Icon from "$lib/ui/components/Icon.svelte";
+  import { t } from "$lib/services/i18n";
 
   interface Props {
     lo: Talk;
@@ -95,14 +96,14 @@
       {/if}
     </div>
     <div>
-      <button class="btn btn-sm" onclick={prevSlide}>
-        <Icon type="left" tip="Previous slide" />
+      <button class="btn btn-sm" onclick={prevSlide} aria-label={t("content.slideBack")}>
+        <Icon type="left" tip={t("content.slideBack")} />
       </button>
-      <button class="btn btn-sm" onclick={nextSlide}>
-        <Icon type="right" tip="Next slide" />
+      <button class="btn btn-sm" onclick={nextSlide} aria-label={t("content.slideForward")}>
+        <Icon type="right" tip={t("content.slideForward")} />
       </button>
-      <button class="btn btn-sm" onclick={toggleFullscreen}>
-        <Icon type="fullScreen" tip="Toggle fullscreen" />
+      <button class="btn btn-sm" onclick={toggleFullscreen} aria-label={t("content.slideFullScreen")}>
+        <Icon type="fullScreen" tip={t("content.slideFullScreen")} />
       </button>
     </div>
   </div>

--- a/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
@@ -7,6 +7,7 @@
   import { PDFWorker, getDocument } from "pdfjs-dist";
   import type { Talk } from "@tutors/tutors-model-lib";
   import Icon from "$lib/ui/components/Icon.svelte";
+  import { t } from "$lib/services/i18n";
   import log from "$lib/services/logger";
 
   pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
@@ -154,20 +155,20 @@
       {pageNum} of {pdfDoc?.numPages}
     </div>
     <div>
-      <button class="btn btn-sm" onclick={onPrevPage}>
-        <Icon type="left" tip={"Back 1 slide"} />
+      <button class="btn btn-sm" onclick={onPrevPage} aria-label={t("content.slideBack")}>
+        <Icon type="left" tip={t("content.slideBack")} />
       </button>
-      <button class="btn btn-sm" onclick={onNextPage}>
-        <Icon type="right" tip={"Forward 1 slide"} />
+      <button class="btn btn-sm" onclick={onNextPage} aria-label={t("content.slideForward")}>
+        <Icon type="right" tip={t("content.slideForward")} />
       </button>
-      <button class="btn btn-sm" onclick={clockwiseRotate}>
-        <Icon type="rotate" tip={"Rotate Slide 90 degrees"} />
+      <button class="btn btn-sm" onclick={clockwiseRotate} aria-label={t("content.slideRotate")}>
+        <Icon type="rotate" tip={t("content.slideRotate")} />
       </button>
-      <button class="btn btn-sm" onclick={downloadPdf}>
-        <Icon type="download" tip={"Download"} />
+      <button class="btn btn-sm" onclick={downloadPdf} aria-label={t("content.slideDownload")}>
+        <Icon type="download" tip={t("content.slideDownload")} />
       </button>
-      <button class="btn btn-sm">
-        <Icon link={lo.pdf} type="fullScreen" target="_blank" tip={"View Full Screen"} />
+      <button class="btn btn-sm" aria-label={t("content.slideFullScreen")}>
+        <Icon link={lo.pdf} type="fullScreen" target="_blank" tip={t("content.slideFullScreen")} />
       </button>
     </div>
   </div>

--- a/src/lib/ui/learning-objects/structure/LoReference.svelte
+++ b/src/lib/ui/learning-objects/structure/LoReference.svelte
@@ -31,7 +31,7 @@
     <span class="mb-1 ml-2"> {@html sanitizeHtml(lo.title ?? "")} </span>
   </a>
   {#if lo.video && lo.type != "panelvideo"}
-    <a class="ml-auto flex pl-4" href={lo.video} onclick={(e) => handleClick(e, lo?.video)}>
+    <a class="ml-auto flex pl-4" href={lo.video} onclick={(e) => handleClick(e, lo?.video)} aria-label="Video: {lo.title}">
       <span class="shrink-0">
         <Icon type="video" width="20" height="20" />
       </span>

--- a/src/lib/ui/navigators/LayoutMenu.svelte
+++ b/src/lib/ui/navigators/LayoutMenu.svelte
@@ -169,4 +169,4 @@
   </div>
 {/snippet}
 
-<Menu {menuSelector} {menuContent} />
+<Menu {menuSelector} {menuContent} ariaLabel={t("nav.layout.tip")} />

--- a/src/lib/ui/navigators/MainNavigator.svelte
+++ b/src/lib/ui/navigators/MainNavigator.svelte
@@ -60,7 +60,7 @@
       <div class="flex items-center">
         <LayoutMenu />
       </div>
-      <span class="mx-2 h-10 w-[1px] bg-gray-400 dark:bg-gray-200"></span>
+      <span class="mx-2 h-10 w-[1px] bg-gray-400 dark:bg-gray-200" role="separator" aria-hidden="true"></span>
       {#if !currentCourse?.value?.isPrivate}
         <div class="relative">
           {#if !tutorsId.value?.login}

--- a/src/lib/ui/navigators/SecondaryNavigator.svelte
+++ b/src/lib/ui/navigators/SecondaryNavigator.svelte
@@ -13,7 +13,7 @@
   });
 </script>
 
-<div role="navigation" aria-label={t("a11y.secondaryNavigation")} class="border-primary-100 bg-primary-50 dark:border-primary-800 z-5 mb-2 {themeClasses.firstDiv} sticky top-0 flex h-12 border-b-[1px]">
+<nav aria-label={t("a11y.secondaryNavigation")} class="border-primary-100 bg-primary-50 dark:border-primary-800 z-5 mb-2 {themeClasses.firstDiv} sticky top-0 flex h-12 border-b-[1px]">
   <Breadcrumbs {lo} {parentCourse} />
   {#if currentCourse?.value}
     <div class="flex flex-auto"></div>
@@ -29,4 +29,4 @@
       <IconBar nav={currentCourse?.value?.wallBar} />
     </div>
   {/if}
-</div>
+</nav>

--- a/src/lib/ui/navigators/buttons/Breadcrumbs.svelte
+++ b/src/lib/ui/navigators/buttons/Breadcrumbs.svelte
@@ -28,12 +28,12 @@
 <div class="mx-8 my-2 flex items-center overflow-hidden p-1">
   <ol class="flex w-full items-center gap-2 min-w-0">
     <li class="flex items-center">
-      <a class="inline-flex items-center hover:underline" href="/"> <TutorsIcon widthPlease="25px" /></a>
+      <a class="inline-flex items-center hover:underline" href="/" aria-label={t("nav.breadcrumbs.goHome")}> <TutorsIcon widthPlease="25px" /></a>
     </li>
     <li class="flex items-center opacity-50" aria-hidden="true">&rsaquo;</li>
     {#if parentCourse}
       <li class="flex items-center">
-        <a class="inline-flex items-center hover:underline" href="/{parentCourse}"> <Icon type="programHome" tip={`Go to Course Home`} /></a>
+        <a class="inline-flex items-center hover:underline" href="/{parentCourse}" aria-label={t("nav.breadcrumbs.goHome")}> <Icon type="programHome" tip={t("nav.breadcrumbs.goHome")} /></a>
       </li>
       <li class="flex items-center opacity-50" aria-hidden="true">&rsaquo;</li>
     {/if}

--- a/src/lib/ui/navigators/buttons/CalendarButton.svelte
+++ b/src/lib/ui/navigators/buttons/CalendarButton.svelte
@@ -9,7 +9,7 @@
 {#if currentCourse?.value?.courseCalendar?.currentWeek}
   {#snippet menuSelector()}
     <div class="hidden w-full lg:flex">
-      <button class="hover:preset-tonal mx-auto inline-flex rounded-lg p-2">
+      <div class="hover:preset-tonal mx-auto inline-flex rounded-lg p-2">
         <span class="my-auto pr-4 pl-2">
           <Icon tip={t("nav.calendar.tip")} type="calendar" />
         </span>
@@ -18,7 +18,7 @@
           <span class="pt-1 text-sm">{t("nav.calendar.label")}</span><br />
           <span class="pb-1 text-lg font-bold">{currentCourse.value?.courseCalendar?.currentWeek.title}</span>
         </span>
-      </button>
+      </div>
     </div>
   {/snippet}
 
@@ -26,5 +26,5 @@
     <Calendar calendar={currentCourse.value?.courseCalendar!} />
   {/snippet}
 
-  <Sidebar {menuSelector} {sidebarContent} />
+  <Sidebar {menuSelector} {sidebarContent} ariaLabel={t("nav.calendar.tip")} />
 {/if}

--- a/src/lib/ui/navigators/buttons/InfoButton.svelte
+++ b/src/lib/ui/navigators/buttons/InfoButton.svelte
@@ -23,4 +23,4 @@
   </article>
 {/snippet}
 
-<Sidebar {menuSelector} {sidebarContent} />
+<Sidebar {menuSelector} {sidebarContent} ariaLabel={t("nav.info.tip")} />

--- a/src/lib/ui/navigators/buttons/OnlineButton.svelte
+++ b/src/lib/ui/navigators/buttons/OnlineButton.svelte
@@ -27,4 +27,4 @@
   </div>
 {/snippet}
 
-<Sidebar position="right" {menuSelector} {sidebarContent} />
+<Sidebar position="right" {menuSelector} {sidebarContent} ariaLabel={t("nav.online.view") + " " + t("nav.online.online")} />

--- a/src/lib/ui/navigators/buttons/SearchButton.svelte
+++ b/src/lib/ui/navigators/buttons/SearchButton.svelte
@@ -54,7 +54,7 @@
   });
 </script>
 
-<button onclick={toggleSearch}>
+<button onclick={toggleSearch} aria-label={t("nav.search.tip")} aria-pressed={isSearching}>
   <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary flex items-center gap-2 rounded-lg p-3 text-sm font-bold">
     <Icon type="search" tip={t("nav.search.tip")} />
     <span class="hidden lg:block"> {isSearching ? t("nav.search.exit") : t("nav.search")}</span>

--- a/src/lib/ui/navigators/buttons/TocButton.svelte
+++ b/src/lib/ui/navigators/buttons/TocButton.svelte
@@ -21,4 +21,4 @@
   </article>
 {/snippet}
 
-<Sidebar position="right" {menuSelector} {sidebarContent} />
+<Sidebar position="right" {menuSelector} {sidebarContent} ariaLabel={t("nav.toc.tip")} />

--- a/src/lib/ui/navigators/tutors-connect/AnonProfile.svelte
+++ b/src/lib/ui/navigators/tutors-connect/AnonProfile.svelte
@@ -27,4 +27,4 @@
   </ul>
 {/snippet}
 
-<Menu {menuSelector} {menuContent} />
+<Menu {menuSelector} {menuContent} ariaLabel={t("menu.anonName")} />

--- a/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
+++ b/src/lib/ui/navigators/tutors-connect/ConnectedProfile.svelte
@@ -66,4 +66,4 @@
   </ul>
 {/snippet}
 
-<Menu {menuSelector} {menuContent} />
+<Menu {menuSelector} {menuContent} ariaLabel={t("menu.profile")} />

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const COURSE_URL = '/course/reference-course';
+
+test.describe('Accessibility Audit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(COURSE_URL);
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('course page has no critical or serious ARIA violations', async ({ page }) => {
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    const critical = results.violations.filter(v => v.impact === 'critical');
+    const serious = results.violations.filter(v => v.impact === 'serious');
+    const moderate = results.violations.filter(v => v.impact === 'moderate');
+    const minor = results.violations.filter(v => v.impact === 'minor');
+
+    const total = results.violations.length;
+    const passed = results.passes.length;
+    const score = passed + total > 0 ? Math.round((passed / (passed + total)) * 100) : 100;
+
+    console.log('');
+    console.log('═══════════════════════════════════════');
+    console.log('       ACCESSIBILITY AUDIT REPORT      ');
+    console.log('═══════════════════════════════════════');
+    console.log(`  Score:    ${score}% (${passed} passed, ${total} violations)`);
+    console.log(`  Critical: ${critical.length}`);
+    console.log(`  Serious:  ${serious.length}`);
+    console.log(`  Moderate: ${moderate.length}`);
+    console.log(`  Minor:    ${minor.length}`);
+    console.log('───────────────────────────────────────');
+
+    for (const violation of results.violations) {
+      console.log(`  [${violation.impact?.toUpperCase()}] ${violation.id}: ${violation.description}`);
+      console.log(`    Help: ${violation.helpUrl}`);
+      console.log(`    Affected: ${violation.nodes.length} element(s)`);
+      for (const node of violation.nodes.slice(0, 3)) {
+        console.log(`      → ${node.target.join(' > ')}`);
+      }
+      if (violation.nodes.length > 3) {
+        console.log(`      ... and ${violation.nodes.length - 3} more`);
+      }
+      console.log('');
+    }
+
+    console.log('═══════════════════════════════════════');
+
+    expect(critical, `${critical.length} critical violation(s) found`).toHaveLength(0);
+    expect(serious, `${serious.length} serious violation(s) found`).toHaveLength(0);
+  });
+
+  test('course page passes landmark and navigation rules', async ({ page }) => {
+    const results = await new AxeBuilder({ page })
+      .withTags(['best-practice'])
+      .analyze();
+
+    const passed = results.passes.length;
+    const total = results.violations.length;
+
+    console.log('');
+    console.log('── Best Practice Rules ──');
+    console.log(`  Passed: ${passed}, Violations: ${total}`);
+
+    for (const violation of results.violations) {
+      console.log(`  [${violation.impact?.toUpperCase()}] ${violation.id}: ${violation.description}`);
+    }
+  });
+
+  test('dark mode has no additional violations', async ({ page }) => {
+    await page.evaluate(() => {
+      document.documentElement.classList.add('dark');
+    });
+    await page.waitForTimeout(500);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+
+    const critical = results.violations.filter(v => v.impact === 'critical');
+    const serious = results.violations.filter(v => v.impact === 'serious');
+
+    console.log('');
+    console.log('── Dark Mode Audit ──');
+    console.log(`  Violations: ${results.violations.length} (${critical.length} critical, ${serious.length} serious)`);
+
+    for (const violation of results.violations) {
+      console.log(`  [${violation.impact?.toUpperCase()}] ${violation.id}: ${violation.description}`);
+    }
+
+    expect(critical, 'Dark mode introduced critical violations').toHaveLength(0);
+    expect(serious, 'Dark mode introduced serious violations').toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `aria-label` to icon-only buttons and links across the codebase (~20 instances fixed)
- Adds `aria-pressed` to the search toggle button for screen reader state communication
- Replaces `div[role="navigation"]` with semantic `<nav>` in SecondaryNavigator
- Adds `role="img"` and `aria-label` to the TutorsIcon SVG
- Adds `aria-label="Close"` to sidebar close triggers
- Adds `scope="col"` and `aria-label` to the Calendar table, `aria-current="date"` on current week
- Adds `rel="noopener noreferrer"` to icon links opening in new windows
- Marks decorative Iconify icons with `aria-hidden="true"` inside links
- Uses i18n `t()` for slide control button labels (TalkMarp, TalkMozilla)
- Adds `aria-label` to Lab sidebar nav elements
- Adds `role="separator"` to visual dividers in MainNavigator
- Fixes `button-name` violations: Tooltip.Trigger rendered as `<span>` via Skeleton's `element` prop
- Fixes `nested-interactive` violations: Icon tooltips no longer create buttons inside buttons/links
- Adds `ariaLabel` prop to `Sidebar` (Dialog.Trigger) and `Menu` (Popover.Trigger) components
- All callers (InfoButton, TocButton, CalendarButton, OnlineButton, LayoutMenu, AnonProfile, ConnectedProfile) now pass `ariaLabel`
- Adds `@axe-core/playwright` for automated WCAG 2.1 AA compliance testing
- Adds `npm run test:a11y` script with dedicated Playwright config

## axe-core Accessibility Audit Report

```
═══════════════════════════════════════
       ACCESSIBILITY AUDIT REPORT      
═══════════════════════════════════════
  Score:    100% (26 passed, 0 violations)
  Critical: 0
  Serious:  0
  Moderate: 0
  Minor:    0
───────────────────────────────────────
═══════════════════════════════════════

── Dark Mode Audit ──
  Violations: 0 (0 critical, 0 serious)

── Best Practice Rules ──
  Passed: 14, Violations: 2
  [MODERATE] landmark-unique: Ensure landmarks are unique
  [MODERATE] page-has-heading-one: Ensure that the page, or at least one
             of its frames contains a level-one heading

  3 passed (9.1s)
```

| Metric | Before | After |
|--------|--------|-------|
| WCAG Score | 93% | **100%** |
| Critical violations | 1 (9 elements) | **0** |
| Serious violations | 1 (18 elements) | **0** |
| Rules passed | 26 | **26** |
| Total violations | 2 | **0** |

## Files changed (20)
**Core:** `Icon.svelte`, `TutorsIcon.svelte`, `Sidebar.svelte`, `Menu.svelte`
**Navigators:** `MainNavigator`, `SecondaryNavigator`, `SearchButton`, `Breadcrumbs`, `LayoutMenu`
**Buttons:** `InfoButton`, `TocButton`, `CalendarButton`, `OnlineButton`
**Profiles:** `AnonProfile`, `ConnectedProfile`
**Content:** `TalkMarp`, `TalkMozilla`, `Calendar`, `Lab`
**Structure:** `LoReference`
**Testing:** `accessibility.spec.ts`, `playwright-a11y.config.ts`
**i18n:** `en.ts`, `fr.ts`, `de.ts`, `it.ts`, `es.ts` (added `menu.profile` key)

## Running the audit
```bash
npm run dev
# in another terminal:
npm run test:a11y
# or with custom port:
BASE_URL=http://localhost:5175 npm run test:a11y
```

## Test plan
- [x] `npm run test:a11y` — 3/3 tests passing, 100% WCAG 2.1 AA score
- [ ] Navigate the app with a screen reader — icon-only buttons should announce their purpose
- [ ] Tab through the main navigator — search button announces pressed/unpressed state
- [ ] Open a lab — sidebar nav is announced as "Lab steps"
- [ ] Open the Calendar sidebar — table headers and current week row are properly announced
- [ ] Verify slide controls in Marp/PDF talks announce "Previous slide", "Next slide", etc.
- [ ] Check that breadcrumb home link announces "Go to Course Home"

🤖 Generated with [Claude Code](https://claude.com/claude-code)