### PR TITLE
Internationalize error page

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { t } from "$lib/services/i18n";
 </script>
 
 <div class="flex min-h-[60vh] flex-col items-center justify-center p-8 text-center">
   <h1 class="text-6xl font-bold text-error-500">{page.status}</h1>
-  <p class="mt-4 text-xl">{page.error?.message ?? "Something went wrong"}</p>
-  <a href="/" class="btn preset-tonal-primary mt-8">Go Home</a>
+  <p class="mt-4 text-xl">{page.error?.message ?? t("error.fallback")}</p>
+  <a href="/" class="btn preset-tonal-primary mt-8">{t("error.goHome")}</a>
 </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `+error.svelte` with `t()` i18n function calls
- Uses existing `error.fallback` and `error.goHome` keys already present in all 5 locale files (en, fr, de, it, es)

## Test plan
- [ ] Trigger a 404 by visiting a non-existent route — verify fallback text renders in the selected locale
- [ ] Switch language and reload the error page — confirm translated strings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)