### PR TITLE
Add keyboard shortcuts overlay, focus mode, and back-to-top button

### DIFF
--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -25,3 +25,4 @@ export const tutorsId = rune<TutorsId | null>(null);
 export const courseProtocol = rune("https://");
 
 export const hideMainNavigator = rune(false);
+export const shortcutsOverlayOpen = rune(false);

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -1,0 +1,69 @@
+import type { MessageKey } from "$lib/services/i18n";
+
+export type ShortcutContext = "general" | "lab" | "talk" | "notebook";
+
+export interface ShortcutDefinition {
+  keys: string[];
+  descriptionKey: MessageKey;
+}
+
+export interface ShortcutCategory {
+  titleKey: MessageKey;
+  context: ShortcutContext;
+  shortcuts: ShortcutDefinition[];
+}
+
+const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
+  {
+    titleKey: "shortcuts.general",
+    context: "general",
+    shortcuts: [
+      { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
+      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.lab",
+    context: "lab",
+    shortcuts: [
+      { keys: ["→", "↓"], descriptionKey: "shortcuts.nextStep" },
+      { keys: ["←", "↑"], descriptionKey: "shortcuts.prevStep" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.talk",
+    context: "talk",
+    shortcuts: [
+      { keys: ["→"], descriptionKey: "shortcuts.nextSlide" },
+      { keys: ["←"], descriptionKey: "shortcuts.prevSlide" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.notebook",
+    context: "notebook",
+    shortcuts: [
+      { keys: ["→", "↓"], descriptionKey: "shortcuts.nextCell" },
+      { keys: ["←", "↑"], descriptionKey: "shortcuts.prevCell" }
+    ]
+  }
+];
+
+function getShortcutContext(loType?: string): ShortcutContext | null {
+  switch (loType) {
+    case "lab":
+    case "step":
+      return "lab";
+    case "talk":
+    case "paneltalk":
+      return "talk";
+    case "notebook":
+      return "notebook";
+    default:
+      return null;
+  }
+}
+
+export function getActiveCategories(loType?: string): ShortcutCategory[] {
+  const context = getShortcutContext(loType);
+  return SHORTCUT_CATEGORIES.filter((cat) => cat.context === "general" || cat.context === context);
+}

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -20,7 +20,8 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     shortcuts: [
       { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
       { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" },
-      { keys: ["F"], descriptionKey: "shortcuts.focusMode" }
+      { keys: ["F"], descriptionKey: "shortcuts.focusMode" },
+      { keys: ["T"], descriptionKey: "shortcuts.backToTop" }
     ]
   },
   {

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -19,7 +19,8 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     context: "general",
     shortcuts: [
       { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
-      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" }
+      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" },
+      { keys: ["F"], descriptionKey: "shortcuts.focusMode" }
     ]
   },
   {

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -138,7 +138,23 @@ const de: Record<string, string> = {
   "a11y.breadcrumbs": "Brotkruemelnavigation",
   "a11y.secondaryNavigation": "Sekundaere Navigation",
   "a11y.sidebar": "Seitenleiste",
-  "a11y.footer": "Seitenfuss"
+  "a11y.footer": "Seitenfuss",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Tastenkuerzel",
+  "shortcuts.close": "Tastenkuerzel schliessen",
+  "shortcuts.general": "Allgemein",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Praesentation",
+  "shortcuts.notebook": "Notizbuch",
+  "shortcuts.showShortcuts": "Tastenkuerzel anzeigen",
+  "shortcuts.closeOverlay": "Dialog schliessen",
+  "shortcuts.nextStep": "Naechster Schritt",
+  "shortcuts.prevStep": "Vorheriger Schritt",
+  "shortcuts.nextSlide": "Naechste Folie",
+  "shortcuts.prevSlide": "Vorherige Folie",
+  "shortcuts.nextCell": "Naechste Zelle",
+  "shortcuts.prevCell": "Vorherige Zelle"
 };
 
 export default de;

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -137,6 +137,7 @@ const de: Record<string, string> = {
   "a11y.mainNavigation": "Hauptnavigation",
   "a11y.breadcrumbs": "Brotkruemelnavigation",
   "a11y.secondaryNavigation": "Sekundaere Navigation",
+  "a11y.backToTop": "Nach oben",
   "a11y.sidebar": "Seitenleiste",
   "a11y.footer": "Seitenfuss",
 
@@ -155,7 +156,8 @@ const de: Record<string, string> = {
   "shortcuts.nextSlide": "Naechste Folie",
   "shortcuts.prevSlide": "Vorherige Folie",
   "shortcuts.nextCell": "Naechste Zelle",
-  "shortcuts.prevCell": "Vorherige Zelle"
+  "shortcuts.prevCell": "Vorherige Zelle",
+  "shortcuts.backToTop": "Nach oben scrollen"
 };
 
 export default de;

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -149,6 +149,7 @@ const de: Record<string, string> = {
   "shortcuts.notebook": "Notizbuch",
   "shortcuts.showShortcuts": "Tastenkuerzel anzeigen",
   "shortcuts.closeOverlay": "Dialog schliessen",
+  "shortcuts.focusMode": "Fokusmodus umschalten",
   "shortcuts.nextStep": "Naechster Schritt",
   "shortcuts.prevStep": "Vorheriger Schritt",
   "shortcuts.nextSlide": "Naechste Folie",

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -150,7 +150,23 @@ Tutors is an open source application - the data collection component [is here](h
   "a11y.breadcrumbs": "Breadcrumbs",
   "a11y.secondaryNavigation": "Secondary navigation",
   "a11y.sidebar": "Sidebar",
-  "a11y.footer": "Site footer"
+  "a11y.footer": "Site footer",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Keyboard Shortcuts",
+  "shortcuts.close": "Close keyboard shortcuts",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentation",
+  "shortcuts.notebook": "Notebook",
+  "shortcuts.showShortcuts": "Show keyboard shortcuts",
+  "shortcuts.closeOverlay": "Close dialog",
+  "shortcuts.nextStep": "Next step",
+  "shortcuts.prevStep": "Previous step",
+  "shortcuts.nextSlide": "Next slide",
+  "shortcuts.prevSlide": "Previous slide",
+  "shortcuts.nextCell": "Next cell",
+  "shortcuts.prevCell": "Previous cell"
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -149,6 +149,7 @@ Tutors is an open source application - the data collection component [is here](h
   "a11y.mainNavigation": "Main navigation",
   "a11y.breadcrumbs": "Breadcrumbs",
   "a11y.secondaryNavigation": "Secondary navigation",
+  "a11y.backToTop": "Back to top",
   "a11y.sidebar": "Sidebar",
   "a11y.footer": "Site footer",
 
@@ -167,7 +168,8 @@ Tutors is an open source application - the data collection component [is here](h
   "shortcuts.nextSlide": "Next slide",
   "shortcuts.prevSlide": "Previous slide",
   "shortcuts.nextCell": "Next cell",
-  "shortcuts.prevCell": "Previous cell"
+  "shortcuts.prevCell": "Previous cell",
+  "shortcuts.backToTop": "Scroll to top"
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -161,6 +161,7 @@ Tutors is an open source application - the data collection component [is here](h
   "shortcuts.notebook": "Notebook",
   "shortcuts.showShortcuts": "Show keyboard shortcuts",
   "shortcuts.closeOverlay": "Close dialog",
+  "shortcuts.focusMode": "Toggle focus mode",
   "shortcuts.nextStep": "Next step",
   "shortcuts.prevStep": "Previous step",
   "shortcuts.nextSlide": "Next slide",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -138,7 +138,23 @@ const es: Record<string, string> = {
   "a11y.breadcrumbs": "Migas de pan",
   "a11y.secondaryNavigation": "Navegacion secundaria",
   "a11y.sidebar": "Barra lateral",
-  "a11y.footer": "Pie de pagina"
+  "a11y.footer": "Pie de pagina",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Atajos de teclado",
+  "shortcuts.close": "Cerrar atajos de teclado",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentacion",
+  "shortcuts.notebook": "Cuaderno",
+  "shortcuts.showShortcuts": "Mostrar atajos de teclado",
+  "shortcuts.closeOverlay": "Cerrar dialogo",
+  "shortcuts.nextStep": "Paso siguiente",
+  "shortcuts.prevStep": "Paso anterior",
+  "shortcuts.nextSlide": "Diapositiva siguiente",
+  "shortcuts.prevSlide": "Diapositiva anterior",
+  "shortcuts.nextCell": "Celda siguiente",
+  "shortcuts.prevCell": "Celda anterior"
 };
 
 export default es;

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -149,6 +149,7 @@ const es: Record<string, string> = {
   "shortcuts.notebook": "Cuaderno",
   "shortcuts.showShortcuts": "Mostrar atajos de teclado",
   "shortcuts.closeOverlay": "Cerrar dialogo",
+  "shortcuts.focusMode": "Alternar modo enfoque",
   "shortcuts.nextStep": "Paso siguiente",
   "shortcuts.prevStep": "Paso anterior",
   "shortcuts.nextSlide": "Diapositiva siguiente",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -137,6 +137,7 @@ const es: Record<string, string> = {
   "a11y.mainNavigation": "Navegacion principal",
   "a11y.breadcrumbs": "Migas de pan",
   "a11y.secondaryNavigation": "Navegacion secundaria",
+  "a11y.backToTop": "Volver arriba",
   "a11y.sidebar": "Barra lateral",
   "a11y.footer": "Pie de pagina",
 
@@ -155,7 +156,8 @@ const es: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositiva siguiente",
   "shortcuts.prevSlide": "Diapositiva anterior",
   "shortcuts.nextCell": "Celda siguiente",
-  "shortcuts.prevCell": "Celda anterior"
+  "shortcuts.prevCell": "Celda anterior",
+  "shortcuts.backToTop": "Volver arriba"
 };
 
 export default es;

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -149,6 +149,7 @@ const fr: Record<string, string> = {
   "shortcuts.notebook": "Carnet",
   "shortcuts.showShortcuts": "Afficher les raccourcis clavier",
   "shortcuts.closeOverlay": "Fermer la boite de dialogue",
+  "shortcuts.focusMode": "Basculer le mode focus",
   "shortcuts.nextStep": "Etape suivante",
   "shortcuts.prevStep": "Etape precedente",
   "shortcuts.nextSlide": "Diapositive suivante",

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -138,7 +138,23 @@ const fr: Record<string, string> = {
   "a11y.breadcrumbs": "Fil d'Ariane",
   "a11y.secondaryNavigation": "Navigation secondaire",
   "a11y.sidebar": "Barre laterale",
-  "a11y.footer": "Pied de page"
+  "a11y.footer": "Pied de page",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Raccourcis clavier",
+  "shortcuts.close": "Fermer les raccourcis clavier",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentation",
+  "shortcuts.notebook": "Carnet",
+  "shortcuts.showShortcuts": "Afficher les raccourcis clavier",
+  "shortcuts.closeOverlay": "Fermer la boite de dialogue",
+  "shortcuts.nextStep": "Etape suivante",
+  "shortcuts.prevStep": "Etape precedente",
+  "shortcuts.nextSlide": "Diapositive suivante",
+  "shortcuts.prevSlide": "Diapositive precedente",
+  "shortcuts.nextCell": "Cellule suivante",
+  "shortcuts.prevCell": "Cellule precedente"
 };
 
 export default fr;

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -137,6 +137,7 @@ const fr: Record<string, string> = {
   "a11y.mainNavigation": "Navigation principale",
   "a11y.breadcrumbs": "Fil d'Ariane",
   "a11y.secondaryNavigation": "Navigation secondaire",
+  "a11y.backToTop": "Retour en haut",
   "a11y.sidebar": "Barre laterale",
   "a11y.footer": "Pied de page",
 
@@ -155,7 +156,8 @@ const fr: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositive suivante",
   "shortcuts.prevSlide": "Diapositive precedente",
   "shortcuts.nextCell": "Cellule suivante",
-  "shortcuts.prevCell": "Cellule precedente"
+  "shortcuts.prevCell": "Cellule precedente",
+  "shortcuts.backToTop": "Retour en haut"
 };
 
 export default fr;

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -149,6 +149,7 @@ const it: Record<string, string> = {
   "shortcuts.notebook": "Quaderno",
   "shortcuts.showShortcuts": "Mostra scorciatoie da tastiera",
   "shortcuts.closeOverlay": "Chiudi finestra di dialogo",
+  "shortcuts.focusMode": "Attiva/disattiva modalita focus",
   "shortcuts.nextStep": "Passo successivo",
   "shortcuts.prevStep": "Passo precedente",
   "shortcuts.nextSlide": "Diapositiva successiva",

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -137,6 +137,7 @@ const it: Record<string, string> = {
   "a11y.mainNavigation": "Navigazione principale",
   "a11y.breadcrumbs": "Breadcrumb",
   "a11y.secondaryNavigation": "Navigazione secondaria",
+  "a11y.backToTop": "Torna in alto",
   "a11y.sidebar": "Barra laterale",
   "a11y.footer": "Pie di pagina",
 
@@ -155,7 +156,8 @@ const it: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositiva successiva",
   "shortcuts.prevSlide": "Diapositiva precedente",
   "shortcuts.nextCell": "Cella successiva",
-  "shortcuts.prevCell": "Cella precedente"
+  "shortcuts.prevCell": "Cella precedente",
+  "shortcuts.backToTop": "Torna in alto"
 };
 
 export default it;

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -138,7 +138,23 @@ const it: Record<string, string> = {
   "a11y.breadcrumbs": "Breadcrumb",
   "a11y.secondaryNavigation": "Navigazione secondaria",
   "a11y.sidebar": "Barra laterale",
-  "a11y.footer": "Pie di pagina"
+  "a11y.footer": "Pie di pagina",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Scorciatoie da tastiera",
+  "shortcuts.close": "Chiudi scorciatoie da tastiera",
+  "shortcuts.general": "Generale",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentazione",
+  "shortcuts.notebook": "Quaderno",
+  "shortcuts.showShortcuts": "Mostra scorciatoie da tastiera",
+  "shortcuts.closeOverlay": "Chiudi finestra di dialogo",
+  "shortcuts.nextStep": "Passo successivo",
+  "shortcuts.prevStep": "Passo precedente",
+  "shortcuts.nextSlide": "Diapositiva successiva",
+  "shortcuts.prevSlide": "Diapositiva precedente",
+  "shortcuts.nextCell": "Cella successiva",
+  "shortcuts.prevCell": "Cella precedente"
 };
 
 export default it;

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -2,7 +2,8 @@
   import Footer from "$lib/ui/navigators/footers/Footer.svelte";
   import { onMount, type Snippet } from "svelte";
   import MainNavigator from "./navigators/MainNavigator.svelte";
-  import { animationDelay, hideMainNavigator } from "$lib/runes.svelte";
+  import { animationDelay, hideMainNavigator, shortcutsOverlayOpen } from "$lib/runes.svelte";
+  import KeyboardShortcutsOverlay from "./components/KeyboardShortcutsOverlay.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -15,7 +16,21 @@
   onMount(() => {
     showFooter = true;
   });
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    const target = e.target as HTMLElement;
+    const tag = target.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
+      return;
+    }
+    if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      shortcutsOverlayOpen.value = !shortcutsOverlayOpen.value;
+    }
+  }
 </script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
 
 <div class="flex h-screen flex-col">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:z-50 focus:p-4 focus:bg-primary-500 focus:text-white">
@@ -42,6 +57,8 @@
       <Footer />
     </footer>
   {/if}
+
+  <KeyboardShortcutsOverlay />
 </div>
 
 <style>

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -4,6 +4,7 @@
   import MainNavigator from "./navigators/MainNavigator.svelte";
   import { animationDelay, hideMainNavigator, shortcutsOverlayOpen } from "$lib/runes.svelte";
   import KeyboardShortcutsOverlay from "./components/KeyboardShortcutsOverlay.svelte";
+  import Icon from "./components/Icon.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -12,10 +13,20 @@
   type Props = { children: Snippet };
   let { children }: Props = $props();
   let showFooter = $state(false);
+  let showBackToTop = $state(false);
+  let mainEl: HTMLElement | undefined = $state();
 
   onMount(() => {
     showFooter = true;
   });
+
+  function onMainScroll() {
+    showBackToTop = (mainEl?.scrollTop ?? 0) > 400;
+  }
+
+  function scrollToTop() {
+    mainEl?.scrollTo({ top: 0, behavior: prefersReducedMotion.value ? "instant" : "smooth" });
+  }
 
   function handleGlobalKeydown(e: KeyboardEvent) {
     const target = e.target as HTMLElement;
@@ -30,6 +41,10 @@
     if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       e.preventDefault();
       hideMainNavigator.value = !hideMainNavigator.value;
+    }
+    if (e.key === "t" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      scrollToTop();
     }
   }
 </script>
@@ -52,7 +67,7 @@
     {/if}
   </header>
 
-  <main id="main-content" tabindex="-1" class="flex-1 overflow-y-auto outline-none">
+  <main id="main-content" tabindex="-1" class="flex-1 overflow-y-auto outline-none" bind:this={mainEl} onscroll={onMainScroll}>
     {@render children()}
   </main>
 
@@ -60,6 +75,18 @@
     <footer transition:slide={{ duration: prefersReducedMotion.value ? 0 : 800 }} class="mt-auto hidden [@media(min-height:800px)]:lg:block" aria-label={t("a11y.footer")}>
       <Footer />
     </footer>
+  {/if}
+
+  {#if showBackToTop}
+    <button
+      class="fixed bottom-6 right-6 z-50 rounded-full bg-primary-500 p-3 text-white shadow-lg
+        transition-opacity hover:bg-primary-600
+        {prefersReducedMotion.value ? '' : 'animate-in fade-in duration-200'}"
+      onclick={scrollToTop}
+      aria-label={t("a11y.backToTop")}
+    >
+      <Icon icon="fluent:arrow-up-24-filled" color="white" height="24" />
+    </button>
   {/if}
 
   <KeyboardShortcutsOverlay />

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -27,6 +27,10 @@
       e.preventDefault();
       shortcutsOverlayOpen.value = !shortcutsOverlayOpen.value;
     }
+    if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      hideMainNavigator.value = !hideMainNavigator.value;
+    }
   }
 </script>
 

--- a/src/lib/ui/components/KeyboardShortcutsOverlay.svelte
+++ b/src/lib/ui/components/KeyboardShortcutsOverlay.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { shortcutsOverlayOpen, currentLo } from "$lib/runes.svelte";
+  import { t } from "$lib/services/i18n";
+  import { getActiveCategories } from "$lib/services/a11y/keyboard-shortcuts";
+  import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
+  import Icon from "./Icon.svelte";
+
+  let dialogEl: HTMLDialogElement | undefined = $state();
+
+  const categories = $derived(getActiveCategories(currentLo.value?.type));
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (shortcutsOverlayOpen.value) {
+      dialogEl.showModal();
+    } else {
+      dialogEl.close();
+    }
+  });
+
+  function onClose() {
+    shortcutsOverlayOpen.value = false;
+  }
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === dialogEl) {
+      onClose();
+    }
+  }
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  class="m-auto max-w-lg w-full rounded-xl bg-surface-50 dark:bg-surface-900 shadow-2xl
+    backdrop:bg-black/50 backdrop:backdrop-blur-sm
+    open:animate-in open:fade-in open:zoom-in-95
+    {prefersReducedMotion.value ? 'open:duration-0' : 'open:duration-200'}
+    p-0 border border-surface-200 dark:border-surface-700"
+  aria-labelledby="shortcuts-title"
+  onclick={onBackdropClick}
+  onclose={onClose}
+>
+  <div class="p-6">
+    <div class="flex items-center justify-between mb-6">
+      <h2 id="shortcuts-title" class="text-xl font-bold">{t("shortcuts.title")}</h2>
+      <button class="btn-icon preset-tonal" onclick={onClose} aria-label={t("shortcuts.close")}>
+        <Icon type="close" />
+      </button>
+    </div>
+
+    {#each categories as category, i}
+      {#if i > 0}
+        <hr class="my-4 border-surface-200 dark:border-surface-700" />
+      {/if}
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-surface-500 dark:text-surface-400 mb-3">
+        {t(category.titleKey)}
+      </h3>
+      <div class="space-y-2">
+        {#each category.shortcuts as shortcut}
+          <div class="flex items-center justify-between py-1">
+            <span class="text-sm">{t(shortcut.descriptionKey)}</span>
+            <div class="flex items-center gap-1">
+              {#each shortcut.keys as key, k}
+                {#if k > 0}
+                  <span class="text-xs text-surface-400">/</span>
+                {/if}
+                <kbd class="inline-flex items-center justify-center min-w-[1.75rem] px-2 py-1
+                  text-xs font-mono font-semibold
+                  bg-surface-200 dark:bg-surface-700
+                  border border-surface-300 dark:border-surface-600
+                  rounded-md shadow-sm">{key}</kbd>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/each}
+
+    <div class="mt-6 pt-4 border-t border-surface-200 dark:border-surface-700">
+      <p class="text-xs text-center text-surface-400">
+        {t("shortcuts.showShortcuts")}: <kbd class="inline-flex items-center justify-center min-w-[1.25rem] px-1.5 py-0.5
+          text-xs font-mono font-semibold
+          bg-surface-200 dark:bg-surface-700
+          border border-surface-300 dark:border-surface-600
+          rounded shadow-sm">?</kbd>
+      </p>
+    </div>
+  </div>
+</dialog>

--- a/src/lib/ui/learning-objects/content/lab/Lab.svelte
+++ b/src/lib/ui/learning-objects/content/lab/Lab.svelte
@@ -7,6 +7,7 @@
   import { sanitizeHtml } from "$lib/utils/sanitize";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     lab: LiveLab;
@@ -37,6 +38,7 @@
   });
 
   async function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
       let step = lab.nextStep();

--- a/src/lib/ui/learning-objects/content/notebook/Notebook.svelte
+++ b/src/lib/ui/learning-objects/content/notebook/Notebook.svelte
@@ -8,6 +8,7 @@
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
   import NotebookCell from "./cells/NotebookCell.svelte";
   import "./notebook-styles.css";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     notebook: LiveNotebook;
@@ -39,6 +40,7 @@
   }
 
   function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowDown" || e.key === "ArrowRight") {
       e.preventDefault();
       const nextIndex = notebook.nextCell();

--- a/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
@@ -6,6 +6,7 @@
   import { renderMarpSlides, buildMarpMarkdown } from "$lib/services/markdown/services/marp-renderer";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import Icon from "$lib/ui/components/Icon.svelte";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     lo: Talk;
@@ -55,6 +56,7 @@
   }
 
   function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
       nextSlide();

--- a/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
@@ -8,6 +8,7 @@
   import type { Talk } from "@tutors/tutors-model-lib";
   import Icon from "$lib/ui/components/Icon.svelte";
   import log from "$lib/services/logger";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
 
@@ -43,6 +44,7 @@
   }
 
   function keypressInput(e) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight") {
       e.preventDefault();
       onNextPage();


### PR DESCRIPTION
## Summary
- Press **?** on any page to open a keyboard shortcuts reference overlay
- Press **F** to toggle **focus mode** — hides nav bar and footer for distraction-free reading
- Press **T** to **scroll to top** from anywhere on the page
- **Floating back-to-top button** appears after scrolling 400px, with smooth scroll animation
- Context-aware: shows shortcuts relevant to the current view (lab, presentation, notebook)
- Uses native `<dialog>` with `showModal()` for proper focus trapping and backdrop
- Arrow keys suppressed in content components while overlay is open
- Fully internationalized across all 5 locales (en, fr, de, it, es)
- Respects `prefers-reduced-motion` for transitions and scroll behavior

## New files
- `src/lib/services/a11y/keyboard-shortcuts.ts` — shortcut data model, categories, and context detection
- `src/lib/ui/components/KeyboardShortcutsOverlay.svelte` — the overlay component with `<kbd>` keycap styling

## Modified files
- `runes.svelte.ts` — added `shortcutsOverlayOpen` rune
- `TutorsShell.svelte` — global `?`, `F`, and `T` keydown handlers (skips input/textarea/select), mounts overlay and back-to-top button
- `Lab.svelte`, `Notebook.svelte`, `TalkMarp.svelte`, `TalkMozilla.svelte` — guard arrow key handlers when overlay is open
- All 5 i18n locale files — 16 new `shortcuts.*` and `a11y.*` keys each

## Shortcuts documented

| Context | Keys | Action |
|---------|------|--------|
| General | `?` | Show keyboard shortcuts |
| General | `Esc` | Close dialog |
| General | `F` | Toggle focus mode |
| General | `T` | Scroll to top |
| Lab | `→` `↓` / `←` `↑` | Next/previous step |
| Presentation | `→` / `←` | Next/previous slide |
| Notebook | `→` `↓` / `←` `↑` | Next/previous cell |

## Test plan
- [ ] Press `?` on any page — overlay opens with General shortcuts including T
- [ ] Press `T` on a scrolled page — scrolls to top
- [ ] Scroll down 400px — floating arrow-up button appears bottom-right
- [ ] Click floating button — scrolls to top
- [ ] Enable `prefers-reduced-motion` — scroll is instant, button has no fade animation
- [ ] Press `F` — nav bar and footer hide/show
- [ ] Navigate to lab/talk/notebook — verify context-specific shortcuts appear
- [ ] Switch language — verify all text translates
- [ ] Type in search input — no shortcuts fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)