### PR TITLE
Add client-side RBAC with course ownership and content locking

### DIFF
--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -26,3 +26,7 @@ export const courseProtocol = rune("https://");
 
 export const hideMainNavigator = rune(false);
 export const shortcutsOverlayOpen = rune(false);
+
+export const isLecturer = rune(false);
+export const courseLecturers = rune<string[]>([]);
+export const contentLocks = rune<Map<string, boolean>>(new Map());

--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -25,3 +25,4 @@ export const tutorsId = rune<TutorsId | null>(null);
 export const courseProtocol = rune("https://");
 
 export const hideMainNavigator = rune(false);
+export const shortcutsOverlayOpen = rune(false);

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -1,0 +1,69 @@
+import type { MessageKey } from "$lib/services/i18n";
+
+export type ShortcutContext = "general" | "lab" | "talk" | "notebook";
+
+export interface ShortcutDefinition {
+  keys: string[];
+  descriptionKey: MessageKey;
+}
+
+export interface ShortcutCategory {
+  titleKey: MessageKey;
+  context: ShortcutContext;
+  shortcuts: ShortcutDefinition[];
+}
+
+const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
+  {
+    titleKey: "shortcuts.general",
+    context: "general",
+    shortcuts: [
+      { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
+      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.lab",
+    context: "lab",
+    shortcuts: [
+      { keys: ["→", "↓"], descriptionKey: "shortcuts.nextStep" },
+      { keys: ["←", "↑"], descriptionKey: "shortcuts.prevStep" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.talk",
+    context: "talk",
+    shortcuts: [
+      { keys: ["→"], descriptionKey: "shortcuts.nextSlide" },
+      { keys: ["←"], descriptionKey: "shortcuts.prevSlide" }
+    ]
+  },
+  {
+    titleKey: "shortcuts.notebook",
+    context: "notebook",
+    shortcuts: [
+      { keys: ["→", "↓"], descriptionKey: "shortcuts.nextCell" },
+      { keys: ["←", "↑"], descriptionKey: "shortcuts.prevCell" }
+    ]
+  }
+];
+
+function getShortcutContext(loType?: string): ShortcutContext | null {
+  switch (loType) {
+    case "lab":
+    case "step":
+      return "lab";
+    case "talk":
+    case "paneltalk":
+      return "talk";
+    case "notebook":
+      return "notebook";
+    default:
+      return null;
+  }
+}
+
+export function getActiveCategories(loType?: string): ShortcutCategory[] {
+  const context = getShortcutContext(loType);
+  return SHORTCUT_CATEGORIES.filter((cat) => cat.context === "general" || cat.context === context);
+}

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -20,7 +20,8 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     shortcuts: [
       { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
       { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" },
-      { keys: ["F"], descriptionKey: "shortcuts.focusMode" }
+      { keys: ["F"], descriptionKey: "shortcuts.focusMode" },
+      { keys: ["T"], descriptionKey: "shortcuts.backToTop" }
     ]
   },
   {

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -21,7 +21,8 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
       { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
       { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" },
       { keys: ["F"], descriptionKey: "shortcuts.focusMode" },
-      { keys: ["T"], descriptionKey: "shortcuts.backToTop" }
+      { keys: ["T"], descriptionKey: "shortcuts.backToTop" },
+      { keys: ["L"], descriptionKey: "shortcuts.toggleLecturer" }
     ]
   },
   {

--- a/src/lib/services/a11y/keyboard-shortcuts.ts
+++ b/src/lib/services/a11y/keyboard-shortcuts.ts
@@ -19,7 +19,8 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     context: "general",
     shortcuts: [
       { keys: ["?"], descriptionKey: "shortcuts.showShortcuts" },
-      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" }
+      { keys: ["Esc"], descriptionKey: "shortcuts.closeOverlay" },
+      { keys: ["F"], descriptionKey: "shortcuts.focusMode" }
     ]
   },
   {

--- a/src/lib/services/community/utils/supabase-client.ts
+++ b/src/lib/services/community/utils/supabase-client.ts
@@ -416,6 +416,57 @@ export async function updateTutorsConnectUserSentiment(githubId: string, sentime
   }
 }
 
+export async function getContentLocks(courseId: string): Promise<{ course_id: string; lo_route: string; locked: boolean; locked_by: string; locked_at: string }[]> {
+  if (PUBLIC_ANON_MODE === "TRUE" || typeof supabase === "undefined") return [];
+  const id = courseId?.trim();
+  if (!id) return [];
+
+  const { data, error } = await supabase.from("tutors_content_locks").select("*").eq("course_id", id);
+
+  if (error) {
+    log.error("getContentLocks failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function upsertContentLock(courseId: string, loRoute: string, locked: boolean, lockedBy: string): Promise<void> {
+  if (PUBLIC_ANON_MODE === "TRUE" || typeof supabase === "undefined") return;
+
+  const { error } = await supabase.from("tutors_content_locks").upsert(
+    {
+      course_id: courseId,
+      lo_route: loRoute,
+      locked,
+      locked_by: lockedBy,
+      locked_at: new Date().toISOString()
+    },
+    { onConflict: "course_id,lo_route" }
+  );
+
+  if (error) {
+    log.error("upsertContentLock failed:", error);
+  }
+}
+
+export async function getLearningRecordsByCourse(courseId: string) {
+  if (PUBLIC_ANON_MODE === "TRUE" || typeof supabase === "undefined") return [];
+  const id = courseId?.trim();
+  if (!id) return [];
+
+  const { data, error } = await supabase
+    .from("learning_records")
+    .select("student_id, lo_id, type, date_last_accessed, duration, count")
+    .eq("course_id", id)
+    .order("date_last_accessed", { ascending: false });
+
+  if (error) {
+    log.error("getLearningRecordsByCourse failed:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
 /**
  * Fetches online_status for a row in tutors-connect-users (mirrors Share Presence / {@link updateTutorsConnectUserOnlineStatus}).
  * @param githubId - Student GitHub login (primary key for the row)

--- a/src/lib/services/course/services/lo-tree.ts
+++ b/src/lib/services/course/services/lo-tree.ts
@@ -1,4 +1,5 @@
-import { courseProtocol } from "$lib/runes.svelte";
+import { courseProtocol, courseLecturers, tutorsId, isLecturer } from "$lib/runes.svelte";
+import { dev } from "$app/environment";
 import {
   allVideoLos,
   convertLoToHtml,
@@ -54,6 +55,24 @@ export function decorateCourseTree(course: Course, courseId: string = "", course
   topicLos.forEach((lo) => course.topicIndex.set(lo.route, lo as Topic));
 
   loadPropertyFlags(course);
+
+  const ownerRaw = (course.properties?.owner as string) ?? "";
+  const lecturersRaw = (course.properties?.lecturers as string) ?? "";
+  const allLecturerLogins = [ownerRaw, ...lecturersRaw.split(",")]
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (dev && allLecturerLogins.length === 0) {
+    const devLogin = "dev-lecturer";
+    allLecturerLogins.push(devLogin);
+    if (!tutorsId.value) {
+      tutorsId.value = { name: "Dev Lecturer", login: devLogin, email: "", image: "", share: "false", sentiment: "" };
+    }
+    isLecturer.value = true;
+  }
+
+  courseLecturers.value = allLecturerLogins;
+
   createCompanions(course);
   createWalls(course);
   // createToc(course);

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -138,7 +138,23 @@ const de: Record<string, string> = {
   "a11y.breadcrumbs": "Brotkruemelnavigation",
   "a11y.secondaryNavigation": "Sekundaere Navigation",
   "a11y.sidebar": "Seitenleiste",
-  "a11y.footer": "Seitenfuss"
+  "a11y.footer": "Seitenfuss",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Tastenkuerzel",
+  "shortcuts.close": "Tastenkuerzel schliessen",
+  "shortcuts.general": "Allgemein",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Praesentation",
+  "shortcuts.notebook": "Notizbuch",
+  "shortcuts.showShortcuts": "Tastenkuerzel anzeigen",
+  "shortcuts.closeOverlay": "Dialog schliessen",
+  "shortcuts.nextStep": "Naechster Schritt",
+  "shortcuts.prevStep": "Vorheriger Schritt",
+  "shortcuts.nextSlide": "Naechste Folie",
+  "shortcuts.prevSlide": "Vorherige Folie",
+  "shortcuts.nextCell": "Naechste Zelle",
+  "shortcuts.prevCell": "Vorherige Zelle"
 };
 
 export default de;

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -137,6 +137,7 @@ const de: Record<string, string> = {
   "a11y.mainNavigation": "Hauptnavigation",
   "a11y.breadcrumbs": "Brotkruemelnavigation",
   "a11y.secondaryNavigation": "Sekundaere Navigation",
+  "a11y.backToTop": "Nach oben",
   "a11y.sidebar": "Seitenleiste",
   "a11y.footer": "Seitenfuss",
 
@@ -155,7 +156,8 @@ const de: Record<string, string> = {
   "shortcuts.nextSlide": "Naechste Folie",
   "shortcuts.prevSlide": "Vorherige Folie",
   "shortcuts.nextCell": "Naechste Zelle",
-  "shortcuts.prevCell": "Vorherige Zelle"
+  "shortcuts.prevCell": "Vorherige Zelle",
+  "shortcuts.backToTop": "Nach oben scrollen"
 };
 
 export default de;

--- a/src/lib/services/i18n/messages/de.ts
+++ b/src/lib/services/i18n/messages/de.ts
@@ -149,6 +149,7 @@ const de: Record<string, string> = {
   "shortcuts.notebook": "Notizbuch",
   "shortcuts.showShortcuts": "Tastenkuerzel anzeigen",
   "shortcuts.closeOverlay": "Dialog schliessen",
+  "shortcuts.focusMode": "Fokusmodus umschalten",
   "shortcuts.nextStep": "Naechster Schritt",
   "shortcuts.prevStep": "Vorheriger Schritt",
   "shortcuts.nextSlide": "Naechste Folie",

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -169,7 +169,8 @@ Tutors is an open source application - the data collection component [is here](h
   "shortcuts.prevSlide": "Previous slide",
   "shortcuts.nextCell": "Next cell",
   "shortcuts.prevCell": "Previous cell",
-  "shortcuts.backToTop": "Scroll to top"
+  "shortcuts.backToTop": "Scroll to top",
+  "shortcuts.toggleLecturer": "Toggle lecturer view (dev)"
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -150,7 +150,23 @@ Tutors is an open source application - the data collection component [is here](h
   "a11y.breadcrumbs": "Breadcrumbs",
   "a11y.secondaryNavigation": "Secondary navigation",
   "a11y.sidebar": "Sidebar",
-  "a11y.footer": "Site footer"
+  "a11y.footer": "Site footer",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Keyboard Shortcuts",
+  "shortcuts.close": "Close keyboard shortcuts",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentation",
+  "shortcuts.notebook": "Notebook",
+  "shortcuts.showShortcuts": "Show keyboard shortcuts",
+  "shortcuts.closeOverlay": "Close dialog",
+  "shortcuts.nextStep": "Next step",
+  "shortcuts.prevStep": "Previous step",
+  "shortcuts.nextSlide": "Next slide",
+  "shortcuts.prevSlide": "Previous slide",
+  "shortcuts.nextCell": "Next cell",
+  "shortcuts.prevCell": "Previous cell"
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -149,6 +149,7 @@ Tutors is an open source application - the data collection component [is here](h
   "a11y.mainNavigation": "Main navigation",
   "a11y.breadcrumbs": "Breadcrumbs",
   "a11y.secondaryNavigation": "Secondary navigation",
+  "a11y.backToTop": "Back to top",
   "a11y.sidebar": "Sidebar",
   "a11y.footer": "Site footer",
 
@@ -167,7 +168,8 @@ Tutors is an open source application - the data collection component [is here](h
   "shortcuts.nextSlide": "Next slide",
   "shortcuts.prevSlide": "Previous slide",
   "shortcuts.nextCell": "Next cell",
-  "shortcuts.prevCell": "Previous cell"
+  "shortcuts.prevCell": "Previous cell",
+  "shortcuts.backToTop": "Scroll to top"
 } as const;
 
 export default en;

--- a/src/lib/services/i18n/messages/en.ts
+++ b/src/lib/services/i18n/messages/en.ts
@@ -161,6 +161,7 @@ Tutors is an open source application - the data collection component [is here](h
   "shortcuts.notebook": "Notebook",
   "shortcuts.showShortcuts": "Show keyboard shortcuts",
   "shortcuts.closeOverlay": "Close dialog",
+  "shortcuts.focusMode": "Toggle focus mode",
   "shortcuts.nextStep": "Next step",
   "shortcuts.prevStep": "Previous step",
   "shortcuts.nextSlide": "Next slide",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -138,7 +138,23 @@ const es: Record<string, string> = {
   "a11y.breadcrumbs": "Migas de pan",
   "a11y.secondaryNavigation": "Navegacion secundaria",
   "a11y.sidebar": "Barra lateral",
-  "a11y.footer": "Pie de pagina"
+  "a11y.footer": "Pie de pagina",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Atajos de teclado",
+  "shortcuts.close": "Cerrar atajos de teclado",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentacion",
+  "shortcuts.notebook": "Cuaderno",
+  "shortcuts.showShortcuts": "Mostrar atajos de teclado",
+  "shortcuts.closeOverlay": "Cerrar dialogo",
+  "shortcuts.nextStep": "Paso siguiente",
+  "shortcuts.prevStep": "Paso anterior",
+  "shortcuts.nextSlide": "Diapositiva siguiente",
+  "shortcuts.prevSlide": "Diapositiva anterior",
+  "shortcuts.nextCell": "Celda siguiente",
+  "shortcuts.prevCell": "Celda anterior"
 };
 
 export default es;

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -149,6 +149,7 @@ const es: Record<string, string> = {
   "shortcuts.notebook": "Cuaderno",
   "shortcuts.showShortcuts": "Mostrar atajos de teclado",
   "shortcuts.closeOverlay": "Cerrar dialogo",
+  "shortcuts.focusMode": "Alternar modo enfoque",
   "shortcuts.nextStep": "Paso siguiente",
   "shortcuts.prevStep": "Paso anterior",
   "shortcuts.nextSlide": "Diapositiva siguiente",

--- a/src/lib/services/i18n/messages/es.ts
+++ b/src/lib/services/i18n/messages/es.ts
@@ -137,6 +137,7 @@ const es: Record<string, string> = {
   "a11y.mainNavigation": "Navegacion principal",
   "a11y.breadcrumbs": "Migas de pan",
   "a11y.secondaryNavigation": "Navegacion secundaria",
+  "a11y.backToTop": "Volver arriba",
   "a11y.sidebar": "Barra lateral",
   "a11y.footer": "Pie de pagina",
 
@@ -155,7 +156,8 @@ const es: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositiva siguiente",
   "shortcuts.prevSlide": "Diapositiva anterior",
   "shortcuts.nextCell": "Celda siguiente",
-  "shortcuts.prevCell": "Celda anterior"
+  "shortcuts.prevCell": "Celda anterior",
+  "shortcuts.backToTop": "Volver arriba"
 };
 
 export default es;

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -149,6 +149,7 @@ const fr: Record<string, string> = {
   "shortcuts.notebook": "Carnet",
   "shortcuts.showShortcuts": "Afficher les raccourcis clavier",
   "shortcuts.closeOverlay": "Fermer la boite de dialogue",
+  "shortcuts.focusMode": "Basculer le mode focus",
   "shortcuts.nextStep": "Etape suivante",
   "shortcuts.prevStep": "Etape precedente",
   "shortcuts.nextSlide": "Diapositive suivante",

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -138,7 +138,23 @@ const fr: Record<string, string> = {
   "a11y.breadcrumbs": "Fil d'Ariane",
   "a11y.secondaryNavigation": "Navigation secondaire",
   "a11y.sidebar": "Barre laterale",
-  "a11y.footer": "Pied de page"
+  "a11y.footer": "Pied de page",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Raccourcis clavier",
+  "shortcuts.close": "Fermer les raccourcis clavier",
+  "shortcuts.general": "General",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentation",
+  "shortcuts.notebook": "Carnet",
+  "shortcuts.showShortcuts": "Afficher les raccourcis clavier",
+  "shortcuts.closeOverlay": "Fermer la boite de dialogue",
+  "shortcuts.nextStep": "Etape suivante",
+  "shortcuts.prevStep": "Etape precedente",
+  "shortcuts.nextSlide": "Diapositive suivante",
+  "shortcuts.prevSlide": "Diapositive precedente",
+  "shortcuts.nextCell": "Cellule suivante",
+  "shortcuts.prevCell": "Cellule precedente"
 };
 
 export default fr;

--- a/src/lib/services/i18n/messages/fr.ts
+++ b/src/lib/services/i18n/messages/fr.ts
@@ -137,6 +137,7 @@ const fr: Record<string, string> = {
   "a11y.mainNavigation": "Navigation principale",
   "a11y.breadcrumbs": "Fil d'Ariane",
   "a11y.secondaryNavigation": "Navigation secondaire",
+  "a11y.backToTop": "Retour en haut",
   "a11y.sidebar": "Barre laterale",
   "a11y.footer": "Pied de page",
 
@@ -155,7 +156,8 @@ const fr: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositive suivante",
   "shortcuts.prevSlide": "Diapositive precedente",
   "shortcuts.nextCell": "Cellule suivante",
-  "shortcuts.prevCell": "Cellule precedente"
+  "shortcuts.prevCell": "Cellule precedente",
+  "shortcuts.backToTop": "Retour en haut"
 };
 
 export default fr;

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -149,6 +149,7 @@ const it: Record<string, string> = {
   "shortcuts.notebook": "Quaderno",
   "shortcuts.showShortcuts": "Mostra scorciatoie da tastiera",
   "shortcuts.closeOverlay": "Chiudi finestra di dialogo",
+  "shortcuts.focusMode": "Attiva/disattiva modalita focus",
   "shortcuts.nextStep": "Passo successivo",
   "shortcuts.prevStep": "Passo precedente",
   "shortcuts.nextSlide": "Diapositiva successiva",

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -137,6 +137,7 @@ const it: Record<string, string> = {
   "a11y.mainNavigation": "Navigazione principale",
   "a11y.breadcrumbs": "Breadcrumb",
   "a11y.secondaryNavigation": "Navigazione secondaria",
+  "a11y.backToTop": "Torna in alto",
   "a11y.sidebar": "Barra laterale",
   "a11y.footer": "Pie di pagina",
 
@@ -155,7 +156,8 @@ const it: Record<string, string> = {
   "shortcuts.nextSlide": "Diapositiva successiva",
   "shortcuts.prevSlide": "Diapositiva precedente",
   "shortcuts.nextCell": "Cella successiva",
-  "shortcuts.prevCell": "Cella precedente"
+  "shortcuts.prevCell": "Cella precedente",
+  "shortcuts.backToTop": "Torna in alto"
 };
 
 export default it;

--- a/src/lib/services/i18n/messages/it.ts
+++ b/src/lib/services/i18n/messages/it.ts
@@ -138,7 +138,23 @@ const it: Record<string, string> = {
   "a11y.breadcrumbs": "Breadcrumb",
   "a11y.secondaryNavigation": "Navigazione secondaria",
   "a11y.sidebar": "Barra laterale",
-  "a11y.footer": "Pie di pagina"
+  "a11y.footer": "Pie di pagina",
+
+  // Keyboard shortcuts
+  "shortcuts.title": "Scorciatoie da tastiera",
+  "shortcuts.close": "Chiudi scorciatoie da tastiera",
+  "shortcuts.general": "Generale",
+  "shortcuts.lab": "Lab",
+  "shortcuts.talk": "Presentazione",
+  "shortcuts.notebook": "Quaderno",
+  "shortcuts.showShortcuts": "Mostra scorciatoie da tastiera",
+  "shortcuts.closeOverlay": "Chiudi finestra di dialogo",
+  "shortcuts.nextStep": "Passo successivo",
+  "shortcuts.prevStep": "Passo precedente",
+  "shortcuts.nextSlide": "Diapositiva successiva",
+  "shortcuts.prevSlide": "Diapositiva precedente",
+  "shortcuts.nextCell": "Cella successiva",
+  "shortcuts.prevCell": "Cella precedente"
 };
 
 export default it;

--- a/src/lib/services/rbac/index.ts
+++ b/src/lib/services/rbac/index.ts
@@ -1,0 +1,2 @@
+export { rbacService } from "./services/rbac.svelte";
+export type { ContentLock } from "./types";

--- a/src/lib/services/rbac/services/rbac.svelte.ts
+++ b/src/lib/services/rbac/services/rbac.svelte.ts
@@ -1,0 +1,78 @@
+import { contentLocks } from "$lib/runes.svelte";
+import { getContentLocks, upsertContentLock } from "$lib/services/community/utils/supabase-client";
+
+function localStorageKey(courseId: string): string {
+  return `tutors-content-locks-${courseId}`;
+}
+
+function loadFromLocalStorage(courseId: string): Map<string, boolean> {
+  try {
+    const raw = localStorage.getItem(localStorageKey(courseId));
+    if (!raw) return new Map();
+    const entries: [string, boolean][] = JSON.parse(raw);
+    return new Map(entries);
+  } catch {
+    return new Map();
+  }
+}
+
+function saveToLocalStorage(courseId: string, locks: Map<string, boolean>): void {
+  try {
+    localStorage.setItem(localStorageKey(courseId), JSON.stringify([...locks.entries()]));
+  } catch {
+    // storage full or unavailable
+  }
+}
+
+export const rbacService = {
+  async loadLocks(courseId: string): Promise<void> {
+    const localMap = loadFromLocalStorage(courseId);
+
+    const supabaseLocks = await getContentLocks(courseId);
+    if (supabaseLocks.length > 0) {
+      const map = new Map<string, boolean>();
+      for (const lock of supabaseLocks) {
+        if (lock.locked) {
+          map.set(lock.lo_route, true);
+        }
+      }
+      contentLocks.value = map;
+      saveToLocalStorage(courseId, map);
+    } else {
+      contentLocks.value = localMap;
+    }
+  },
+
+  async toggleLock(courseId: string, loRoute: string, lecturerLogin: string): Promise<void> {
+    const currentlyLocked = contentLocks.value.get(loRoute) ?? false;
+    const newState = !currentlyLocked;
+
+    const updated = new Map(contentLocks.value);
+    if (newState) {
+      updated.set(loRoute, true);
+    } else {
+      updated.delete(loRoute);
+    }
+    contentLocks.value = updated;
+    saveToLocalStorage(courseId, updated);
+
+    upsertContentLock(courseId, loRoute, newState, lecturerLogin);
+  },
+
+  async setLock(courseId: string, loRoute: string, locked: boolean, lecturerLogin: string): Promise<void> {
+    const updated = new Map(contentLocks.value);
+    if (locked) {
+      updated.set(loRoute, true);
+    } else {
+      updated.delete(loRoute);
+    }
+    contentLocks.value = updated;
+    saveToLocalStorage(courseId, updated);
+
+    upsertContentLock(courseId, loRoute, locked, lecturerLogin);
+  },
+
+  isLocked(loRoute: string): boolean {
+    return contentLocks.value.get(loRoute) ?? false;
+  }
+};

--- a/src/lib/services/rbac/types.ts
+++ b/src/lib/services/rbac/types.ts
@@ -1,0 +1,7 @@
+export type ContentLock = {
+  course_id: string;
+  lo_route: string;
+  locked: boolean;
+  locked_by: string;
+  locked_at: string;
+};

--- a/src/lib/services/themes/icons/easter-icons.ts
+++ b/src/lib/services/themes/icons/easter-icons.ts
@@ -78,5 +78,10 @@ export const EasterIcons: IconLib = {
   confused: { type: "twemoji:face-with-spiral-eyes", color: "secondary" },
   drained: { type: "twemoji:melting-face", color: "error" },
 
+  // rbac icons
+  lock: { type: "fluent:lock-closed-24-filled", color: "warning" },
+  unlock: { type: "fluent:lock-open-24-regular", color: "success" },
+  lecturer: { type: "fluent:person-board-24-filled", color: "primary" },
+
   default: { type: "fluent:re-order-dots-vertical-24-filled", color: "error" }
 };

--- a/src/lib/services/themes/icons/festive-icons.ts
+++ b/src/lib/services/themes/icons/festive-icons.ts
@@ -78,5 +78,10 @@ export const FestiveIcons: IconLib = {
   confused: { type: "twemoji:face-with-spiral-eyes", color: "secondary" },
   drained: { type: "twemoji:melting-face", color: "error" },
 
+  // rbac icons
+  lock: { type: "fluent:lock-closed-24-filled", color: "warning" },
+  unlock: { type: "fluent:lock-open-24-regular", color: "success" },
+  lecturer: { type: "fluent:person-board-24-filled", color: "primary" },
+
   default: { type: "fluent:re-order-dots-vertical-24-filled", color: "error" }
 };

--- a/src/lib/services/themes/icons/fluent-icons.ts
+++ b/src/lib/services/themes/icons/fluent-icons.ts
@@ -81,5 +81,10 @@ export const FluentIconLib: IconLib = {
   confused: { type: "twemoji:face-with-spiral-eyes", color: "secondary" },
   drained: { type: "twemoji:melting-face", color: "error" },
 
+  // rbac icons
+  lock: { type: "fluent:lock-closed-24-filled", color: "warning" },
+  unlock: { type: "fluent:lock-open-24-regular", color: "success" },
+  lecturer: { type: "fluent:person-board-24-filled", color: "primary" },
+
   default: { type: "fluent:re-order-dots-vertical-24-filled", color: "error" }
 };

--- a/src/lib/services/themes/icons/hero-icons.ts
+++ b/src/lib/services/themes/icons/hero-icons.ts
@@ -78,5 +78,10 @@ export const HeroIconLib: IconLib = {
   confused: { type: "twemoji:face-with-spiral-eyes", color: "secondary" },
   drained: { type: "twemoji:melting-face", color: "error" },
 
+  // rbac icons
+  lock: { type: "heroicons-outline:lock-closed", color: "warning" },
+  unlock: { type: "heroicons-outline:lock-open", color: "success" },
+  lecturer: { type: "heroicons-outline:academic-cap", color: "primary" },
+
   default: { type: "heroicons-outline:dots-vertical", color: "primary" }
 };

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -2,7 +2,8 @@
   import Footer from "$lib/ui/navigators/footers/Footer.svelte";
   import { onMount, type Snippet } from "svelte";
   import MainNavigator from "./navigators/MainNavigator.svelte";
-  import { animationDelay, hideMainNavigator, shortcutsOverlayOpen } from "$lib/runes.svelte";
+  import { animationDelay, hideMainNavigator, shortcutsOverlayOpen, isLecturer, courseLecturers } from "$lib/runes.svelte";
+  import { dev } from "$app/environment";
   import KeyboardShortcutsOverlay from "./components/KeyboardShortcutsOverlay.svelte";
   import Icon from "./components/Icon.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
@@ -45,6 +46,10 @@
     if (e.key === "t" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       e.preventDefault();
       scrollToTop();
+    }
+    if (dev && e.key === "l" && !e.ctrlKey && !e.metaKey && !e.altKey && courseLecturers.value.length > 0) {
+      e.preventDefault();
+      isLecturer.value = !isLecturer.value;
     }
   }
 </script>

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -2,7 +2,8 @@
   import Footer from "$lib/ui/navigators/footers/Footer.svelte";
   import { onMount, type Snippet } from "svelte";
   import MainNavigator from "./navigators/MainNavigator.svelte";
-  import { animationDelay, hideMainNavigator } from "$lib/runes.svelte";
+  import { animationDelay, hideMainNavigator, shortcutsOverlayOpen } from "$lib/runes.svelte";
+  import KeyboardShortcutsOverlay from "./components/KeyboardShortcutsOverlay.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -15,7 +16,21 @@
   onMount(() => {
     showFooter = true;
   });
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    const target = e.target as HTMLElement;
+    const tag = target.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
+      return;
+    }
+    if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      shortcutsOverlayOpen.value = !shortcutsOverlayOpen.value;
+    }
+  }
 </script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
 
 <div class="flex h-screen flex-col">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:z-50 focus:p-4 focus:bg-primary-500 focus:text-white">
@@ -42,6 +57,8 @@
       <Footer />
     </footer>
   {/if}
+
+  <KeyboardShortcutsOverlay />
 </div>
 
 <style>

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -4,6 +4,7 @@
   import MainNavigator from "./navigators/MainNavigator.svelte";
   import { animationDelay, hideMainNavigator, shortcutsOverlayOpen } from "$lib/runes.svelte";
   import KeyboardShortcutsOverlay from "./components/KeyboardShortcutsOverlay.svelte";
+  import Icon from "./components/Icon.svelte";
   import { cubicIn, cubicOut } from "svelte/easing";
   import { fly, slide } from "svelte/transition";
   import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
@@ -12,10 +13,20 @@
   type Props = { children: Snippet };
   let { children }: Props = $props();
   let showFooter = $state(false);
+  let showBackToTop = $state(false);
+  let mainEl: HTMLElement | undefined = $state();
 
   onMount(() => {
     showFooter = true;
   });
+
+  function onMainScroll() {
+    showBackToTop = (mainEl?.scrollTop ?? 0) > 400;
+  }
+
+  function scrollToTop() {
+    mainEl?.scrollTo({ top: 0, behavior: prefersReducedMotion.value ? "instant" : "smooth" });
+  }
 
   function handleGlobalKeydown(e: KeyboardEvent) {
     const target = e.target as HTMLElement;
@@ -30,6 +41,10 @@
     if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       e.preventDefault();
       hideMainNavigator.value = !hideMainNavigator.value;
+    }
+    if (e.key === "t" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      scrollToTop();
     }
   }
 </script>
@@ -52,7 +67,7 @@
     {/if}
   </header>
 
-  <main id="main-content" tabindex="-1" class="flex-1 overflow-y-auto outline-none">
+  <main id="main-content" tabindex="-1" class="flex-1 overflow-y-auto outline-none" bind:this={mainEl} onscroll={onMainScroll}>
     {@render children()}
   </main>
 
@@ -60,6 +75,18 @@
     <footer transition:slide={{ duration: prefersReducedMotion.value ? 0 : 800 }} class="mt-auto hidden [@media(min-height:800px)]:lg:block" aria-label={t("a11y.footer")}>
       <Footer />
     </footer>
+  {/if}
+
+  {#if showBackToTop}
+    <button
+      class="fixed bottom-6 right-6 z-50 rounded-full bg-primary-500 p-3 text-white shadow-lg
+        transition-opacity hover:bg-primary-600
+        {prefersReducedMotion.value ? '' : 'animate-in fade-in duration-200'}"
+      onclick={scrollToTop}
+      aria-label={t("a11y.backToTop")}
+    >
+      <Icon icon="fluent:arrow-up-24-filled" color="white" height="24" />
+    </button>
   {/if}
 
   <KeyboardShortcutsOverlay />

--- a/src/lib/ui/TutorsShell.svelte
+++ b/src/lib/ui/TutorsShell.svelte
@@ -27,6 +27,10 @@
       e.preventDefault();
       shortcutsOverlayOpen.value = !shortcutsOverlayOpen.value;
     }
+    if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      hideMainNavigator.value = !hideMainNavigator.value;
+    }
   }
 </script>
 

--- a/src/lib/ui/components/KeyboardShortcutsOverlay.svelte
+++ b/src/lib/ui/components/KeyboardShortcutsOverlay.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { shortcutsOverlayOpen, currentLo } from "$lib/runes.svelte";
+  import { t } from "$lib/services/i18n";
+  import { getActiveCategories } from "$lib/services/a11y/keyboard-shortcuts";
+  import { prefersReducedMotion } from "$lib/services/a11y/reduced-motion.svelte";
+  import Icon from "./Icon.svelte";
+
+  let dialogEl: HTMLDialogElement | undefined = $state();
+
+  const categories = $derived(getActiveCategories(currentLo.value?.type));
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (shortcutsOverlayOpen.value) {
+      dialogEl.showModal();
+    } else {
+      dialogEl.close();
+    }
+  });
+
+  function onClose() {
+    shortcutsOverlayOpen.value = false;
+  }
+
+  function onBackdropClick(e: MouseEvent) {
+    if (e.target === dialogEl) {
+      onClose();
+    }
+  }
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  class="m-auto max-w-lg w-full rounded-xl bg-surface-50 dark:bg-surface-900 shadow-2xl
+    backdrop:bg-black/50 backdrop:backdrop-blur-sm
+    open:animate-in open:fade-in open:zoom-in-95
+    {prefersReducedMotion.value ? 'open:duration-0' : 'open:duration-200'}
+    p-0 border border-surface-200 dark:border-surface-700"
+  aria-labelledby="shortcuts-title"
+  onclick={onBackdropClick}
+  onclose={onClose}
+>
+  <div class="p-6">
+    <div class="flex items-center justify-between mb-6">
+      <h2 id="shortcuts-title" class="text-xl font-bold">{t("shortcuts.title")}</h2>
+      <button class="btn-icon preset-tonal" onclick={onClose} aria-label={t("shortcuts.close")}>
+        <Icon type="close" />
+      </button>
+    </div>
+
+    {#each categories as category, i}
+      {#if i > 0}
+        <hr class="my-4 border-surface-200 dark:border-surface-700" />
+      {/if}
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-surface-500 dark:text-surface-400 mb-3">
+        {t(category.titleKey)}
+      </h3>
+      <div class="space-y-2">
+        {#each category.shortcuts as shortcut}
+          <div class="flex items-center justify-between py-1">
+            <span class="text-sm">{t(shortcut.descriptionKey)}</span>
+            <div class="flex items-center gap-1">
+              {#each shortcut.keys as key, k}
+                {#if k > 0}
+                  <span class="text-xs text-surface-400">/</span>
+                {/if}
+                <kbd class="inline-flex items-center justify-center min-w-[1.75rem] px-2 py-1
+                  text-xs font-mono font-semibold
+                  bg-surface-200 dark:bg-surface-700
+                  border border-surface-300 dark:border-surface-600
+                  rounded-md shadow-sm">{key}</kbd>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/each}
+
+    <div class="mt-6 pt-4 border-t border-surface-200 dark:border-surface-700">
+      <p class="text-xs text-center text-surface-400">
+        {t("shortcuts.showShortcuts")}: <kbd class="inline-flex items-center justify-center min-w-[1.25rem] px-1.5 py-0.5
+          text-xs font-mono font-semibold
+          bg-surface-200 dark:bg-surface-700
+          border border-surface-300 dark:border-surface-600
+          rounded shadow-sm">?</kbd>
+      </p>
+    </div>
+  </div>
+</dialog>

--- a/src/lib/ui/learning-objects/content/LecturerPanel.svelte
+++ b/src/lib/ui/learning-objects/content/LecturerPanel.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import { currentCourse, isLecturer, contentLocks, tutorsId } from "$lib/runes.svelte";
+  import { rbacService } from "$lib/services/rbac";
+  import { getTutorsConnectLatestLosByCourseId, getLearningRecordsByCourse } from "$lib/services/community/utils/supabase-client";
+  import Icon from "$lib/ui/components/Icon.svelte";
+  import { flattenLos } from "@tutors/tutors-model-lib";
+
+  let activeTab = $state<"locks" | "enrollment" | "analytics">("locks");
+
+  let learningRecords = $state<any[]>([]);
+  let latestActivity = $state<any[]>([]);
+  let analyticsLoaded = $state(false);
+
+  async function loadAnalytics() {
+    if (analyticsLoaded || !currentCourse.value) return;
+    const courseId = currentCourse.value.courseId;
+    const [records, latest] = await Promise.all([
+      getLearningRecordsByCourse(courseId),
+      getTutorsConnectLatestLosByCourseId(courseId)
+    ]);
+    learningRecords = records;
+    latestActivity = latest;
+    analyticsLoaded = true;
+  }
+
+  function getAllLockableLos() {
+    if (!currentCourse.value) return [];
+    const allLos = flattenLos(currentCourse.value.los);
+    return allLos.filter((lo) => lo.type === "topic" || lo.type === "unit" || lo.type === "lab" || lo.type === "note" || lo.type === "talk" || lo.type === "tutorial");
+  }
+
+  function formatDate(iso: string): string {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+  }
+</script>
+
+{#if isLecturer.value && currentCourse.value}
+  <div class="flex flex-col gap-4 p-2">
+    <div class="flex gap-1 rounded-lg bg-surface-200 p-1 dark:bg-surface-700">
+      <button
+        class="flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors {activeTab === 'locks' ? 'bg-surface-50 dark:bg-surface-800 shadow-sm' : 'hover:bg-surface-300 dark:hover:bg-surface-600'}"
+        onclick={() => (activeTab = "locks")}
+      >
+        Locks
+      </button>
+      <button
+        class="flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors {activeTab === 'enrollment' ? 'bg-surface-50 dark:bg-surface-800 shadow-sm' : 'hover:bg-surface-300 dark:hover:bg-surface-600'}"
+        onclick={() => (activeTab = "enrollment")}
+      >
+        Enrollment
+      </button>
+      <button
+        class="flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors {activeTab === 'analytics' ? 'bg-surface-50 dark:bg-surface-800 shadow-sm' : 'hover:bg-surface-300 dark:hover:bg-surface-600'}"
+        onclick={() => {
+          activeTab = "analytics";
+          loadAnalytics();
+        }}
+      >
+        Access
+      </button>
+    </div>
+
+    {#if activeTab === "locks"}
+      <div class="flex flex-col gap-1">
+        {#each getAllLockableLos() as lo}
+          <div class="flex items-center justify-between rounded-lg px-3 py-2 hover:bg-surface-200 dark:hover:bg-surface-700">
+            <div class="flex items-center gap-2 overflow-hidden">
+              <Icon type={lo.type} height="18" />
+              <span class="truncate text-sm">{lo.title}</span>
+            </div>
+            <button
+              class="shrink-0 rounded-md p-1 transition-colors hover:bg-surface-300 dark:hover:bg-surface-600"
+              onclick={() => rbacService.toggleLock(currentCourse.value!.courseId, lo.route, tutorsId.value!.login)}
+            >
+              <Icon type={contentLocks.value.get(lo.route) ? "lock" : "unlock"} height="18" />
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if activeTab === "enrollment"}
+      <div class="flex flex-col gap-3">
+        {#if currentCourse.value.enrollment?.whitelist && currentCourse.value.enrollment.whitelist.length > 0}
+          <div>
+            <h4 class="text-surface-500 mb-2 text-sm font-medium">Allowlist ({currentCourse.value.enrollment.whitelist.length})</h4>
+            <div class="flex flex-col gap-1">
+              {#each currentCourse.value.enrollment.whitelist as login}
+                <div class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm">
+                  <Icon type="github" height="16" />
+                  <span>{login}</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+        {#if currentCourse.value.enrollment?.students && currentCourse.value.enrollment.students.length > 0}
+          <div>
+            <h4 class="text-surface-500 mb-2 text-sm font-medium">Students ({currentCourse.value.enrollment.students.length})</h4>
+            <div class="flex flex-col gap-1">
+              {#each currentCourse.value.enrollment.students as student}
+                <div class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm">
+                  <span class="font-medium">{student.name}</span>
+                  <span class="text-surface-400">({student.id})</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+        {#if !currentCourse.value.enrollment?.whitelist?.length && !currentCourse.value.enrollment?.students?.length}
+          <p class="text-surface-400 px-3 py-4 text-center text-sm">No enrollment data configured for this course.</p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if activeTab === "analytics"}
+      <div class="flex flex-col gap-3">
+        {#if !analyticsLoaded}
+          <p class="text-surface-400 px-3 py-4 text-center text-sm">Loading...</p>
+        {:else}
+          {#if latestActivity.length > 0}
+            <div>
+              <h4 class="text-surface-500 mb-2 text-sm font-medium">Recent Activity ({latestActivity.length})</h4>
+              <div class="flex flex-col gap-1">
+                {#each latestActivity as activity}
+                  <div class="rounded-lg px-3 py-1.5 text-sm hover:bg-surface-200 dark:hover:bg-surface-700">
+                    <div class="flex items-center justify-between">
+                      <span class="font-medium">{activity.student_id}</span>
+                      <span class="text-surface-400 text-xs">{formatDate(activity.received_at)}</span>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {/if}
+          {#if learningRecords.length > 0}
+            <div>
+              <h4 class="text-surface-500 mb-2 text-sm font-medium">Learning Records ({learningRecords.length})</h4>
+              <div class="flex max-h-64 flex-col gap-1 overflow-y-auto">
+                {#each learningRecords.slice(0, 50) as record}
+                  <div class="rounded-lg px-3 py-1.5 text-sm hover:bg-surface-200 dark:hover:bg-surface-700">
+                    <div class="flex items-center justify-between">
+                      <span class="font-medium">{record.student_id}</span>
+                      <span class="text-surface-400 text-xs">{record.type}</span>
+                    </div>
+                    <div class="text-surface-400 truncate text-xs">{record.lo_id}</div>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {/if}
+          {#if latestActivity.length === 0 && learningRecords.length === 0}
+            <p class="text-surface-400 px-3 py-4 text-center text-sm">No access data recorded yet.</p>
+          {/if}
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/ui/learning-objects/content/lab/Lab.svelte
+++ b/src/lib/ui/learning-objects/content/lab/Lab.svelte
@@ -7,6 +7,7 @@
   import { sanitizeHtml } from "$lib/utils/sanitize";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     lab: LiveLab;
@@ -37,6 +38,7 @@
   });
 
   async function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
       let step = lab.nextStep();

--- a/src/lib/ui/learning-objects/content/notebook/Notebook.svelte
+++ b/src/lib/ui/learning-objects/content/notebook/Notebook.svelte
@@ -8,6 +8,7 @@
   import { copyCode } from "$lib/services/markdown/actions/copy-code-action";
   import NotebookCell from "./cells/NotebookCell.svelte";
   import "./notebook-styles.css";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     notebook: LiveNotebook;
@@ -39,6 +40,7 @@
   }
 
   function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowDown" || e.key === "ArrowRight") {
       e.preventDefault();
       const nextIndex = notebook.nextCell();

--- a/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMarp.svelte
@@ -6,6 +6,7 @@
   import { renderMarpSlides, buildMarpMarkdown } from "$lib/services/markdown/services/marp-renderer";
   import { mermaidify } from "$lib/services/markdown/services/mermaid-action";
   import Icon from "$lib/ui/components/Icon.svelte";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   interface Props {
     lo: Talk;
@@ -55,6 +56,7 @@
   }
 
   function keypressInput(e: KeyboardEvent) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
       nextSlide();

--- a/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
+++ b/src/lib/ui/learning-objects/content/talk/TalkMozilla.svelte
@@ -8,6 +8,7 @@
   import type { Talk } from "@tutors/tutors-model-lib";
   import Icon from "$lib/ui/components/Icon.svelte";
   import log from "$lib/services/logger";
+  import { shortcutsOverlayOpen } from "$lib/runes.svelte";
 
   pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
 
@@ -43,6 +44,7 @@
   }
 
   function keypressInput(e) {
+    if (shortcutsOverlayOpen.value) return;
     if (e.key === "ArrowRight") {
       e.preventDefault();
       onNextPage();

--- a/src/lib/ui/learning-objects/layout/Cards.svelte
+++ b/src/lib/ui/learning-objects/layout/Cards.svelte
@@ -4,10 +4,12 @@
   import type { Lo } from "@tutors/tutors-model-lib";
 
   import Card from "$lib/ui/learning-objects/layout/Card.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
   import { scale } from "svelte/transition";
   import { scaleTransition } from "$lib/ui/navigators/animations";
-  import { currentCourse } from "$lib/runes.svelte";
+  import { currentCourse, isLecturer, contentLocks, tutorsId } from "$lib/runes.svelte";
   import { setShowHide } from "@tutors/tutors-model-lib";
+  import { rbacService } from "$lib/services/rbac";
 
   interface Props {
     los?: Lo[];
@@ -53,10 +55,15 @@
       {#key refresh}
         {#each los as lo}
           {#if !lo.hide}
-            <div class="flex justify-center">
+            <div class="relative flex justify-center">
+              {#if contentLocks.value.get(lo.route) && !isLecturer.value}
+                <div class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-surface-500/30 backdrop-blur-[2px]">
+                  <Icon type="lock" height="48" />
+                </div>
+              {/if}
               <Card
                 cardDetails={{
-                  route: lo.route,
+                  route: contentLocks.value.get(lo.route) && !isLecturer.value ? "#" : lo.route,
                   title: lo.title,
                   type: lo.type,
                   summary: lo.summary,
@@ -65,6 +72,14 @@
                   video: lo.video
                 }}
               />
+              {#if isLecturer.value}
+                <button
+                  class="absolute top-2 right-2 z-20 rounded-lg bg-surface-200 p-1 opacity-70 transition-opacity hover:opacity-100 dark:bg-surface-700"
+                  onclick={() => rbacService.toggleLock(currentCourse.value!.courseId, lo.route, tutorsId.value!.login)}
+                >
+                  <Icon type={contentLocks.value.get(lo.route) ? "lock" : "unlock"} height="20" />
+                </button>
+              {/if}
             </div>
           {/if}
         {/each}

--- a/src/lib/ui/learning-objects/layout/Units.svelte
+++ b/src/lib/ui/learning-objects/layout/Units.svelte
@@ -3,6 +3,9 @@
   import Panels from "./Panels.svelte";
   import Cards from "./Cards.svelte";
   import Image from "$lib/ui/components/Image.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
+  import { currentCourse, isLecturer, contentLocks, tutorsId } from "$lib/runes.svelte";
+  import { rbacService } from "$lib/services/rbac";
 
   interface Props {
     units: Composite[];
@@ -12,12 +15,27 @@
 
 <div class="w-full">
   {#each units as unit}
-    <div class="border-primary-500 bg-surface-100 dark:bg-surface-900 mb-2 w-full overflow-hidden rounded-xl border-[1px] p-4">
+    <div class="relative border-primary-500 bg-surface-100 dark:bg-surface-900 mb-2 w-full overflow-hidden rounded-xl border-[1px] p-4">
+      {#if contentLocks.value.get(unit.route) && !isLecturer.value}
+        <div class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-surface-500/30 backdrop-blur-[2px]">
+          <Icon type="lock" height="48" />
+        </div>
+      {/if}
       <div class="flex w-full justify-between pb-2">
         <h2 id={unit.id} class="p-2 text-xl font-semibold">
           {unit.title}
         </h2>
-        <Image lo={unit.parentTopic ? unit.parentTopic : unit.parentLo} miniImage={true} />
+        <div class="flex items-center gap-2">
+          {#if isLecturer.value}
+            <button
+              class="rounded-lg bg-surface-200 p-1 opacity-70 transition-opacity hover:opacity-100 dark:bg-surface-700"
+              onclick={() => rbacService.toggleLock(currentCourse.value!.courseId, unit.route, tutorsId.value!.login)}
+            >
+              <Icon type={contentLocks.value.get(unit.route) ? "lock" : "unlock"} height="20" />
+            </button>
+          {/if}
+          <Image lo={unit.parentTopic ? unit.parentTopic : unit.parentLo} miniImage={true} />
+        </div>
       </div>
       <Panels panels={unit.panels} />
       <div class="w-full">

--- a/src/lib/ui/navigators/MainNavigator.svelte
+++ b/src/lib/ui/navigators/MainNavigator.svelte
@@ -11,8 +11,9 @@
   import ConnectedProfile from "./tutors-connect/ConnectedProfile.svelte";
   import TutorsTitle from "./titles/TutorsTitle.svelte";
   import CalendarButton from "./buttons/CalendarButton.svelte";
+  import LecturerButton from "./buttons/LecturerButton.svelte";
   import CourseSentimentButton from "./buttons/CourseSentimentButton.svelte";
-  import { currentCourse, tutorsId } from "$lib/runes.svelte";
+  import { currentCourse, tutorsId, isLecturer } from "$lib/runes.svelte";
   import { t } from "$lib/services/i18n";
 </script>
 
@@ -39,6 +40,11 @@
 
     <AppBar.Trail>
       <CalendarButton />
+      {#if isLecturer.value}
+        <span class="hidden md:block">
+          <LecturerButton />
+        </span>
+      {/if}
       {#if tutorsId.value?.login && tutorsId.value?.share === "true"}
         <div class="flex items-center">
           <CourseSentimentButton />

--- a/src/lib/ui/navigators/buttons/LecturerButton.svelte
+++ b/src/lib/ui/navigators/buttons/LecturerButton.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Sidebar from "$lib/ui/components/Sidebar.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
+  import LecturerPanel from "$lib/ui/learning-objects/content/LecturerPanel.svelte";
+  import { currentCourse } from "$lib/runes.svelte";
+</script>
+
+{#snippet menuSelector()}
+  <div class="hover:preset-tonal-secondary dark:hover:preset-tonal-tertiary rounded-lg p-2">
+    <Icon type="lecturer" tip="Lecturer Panel" height="40" />
+  </div>
+{/snippet}
+
+{#snippet sidebarContent()}
+  <header class="text-center">
+    <h3 class="text-surface-500 text-lg">{currentCourse?.value?.title} - Lecturer</h3>
+  </header>
+  <article>
+    <LecturerPanel />
+  </article>
+{/snippet}
+
+<Sidebar position="right" {menuSelector} {sidebarContent} />

--- a/src/routes/(course-reader)/+layout.svelte
+++ b/src/routes/(course-reader)/+layout.svelte
@@ -3,8 +3,10 @@
   import type { Snippet } from "svelte";
   import { tutorsConnectService } from "$lib/services/connect";
   import { page } from "$app/state";
-  import { currentCourse } from "$lib/runes.svelte";
+  import { currentCourse, tutorsId, isLecturer, courseLecturers, contentLocks } from "$lib/runes.svelte";
+  import { rbacService } from "$lib/services/rbac";
   import { afterNavigate } from "$app/navigation";
+  import { goto } from "$app/navigation";
 
   type Props = { children: Snippet };
   let { children }: Props = $props();
@@ -19,10 +21,22 @@
       tutorsConnectService.checkWhiteList();
       tutorsConnectService.courseVisit(currentCourse.value!);
       lastCourseId = currentCourse.value?.courseId!;
+
+      const login = tutorsId.value?.login?.toLowerCase();
+      isLecturer.value = !!login && courseLecturers.value.includes(login);
+      rbacService.loadLocks(currentCourse.value!.courseId);
     }
   });
 
-  afterNavigate(() => {
+  afterNavigate(({ to }) => {
+    if (!isLecturer.value && to?.url?.pathname && currentCourse.value) {
+      const lo = currentCourse.value.loIndex?.get(to.url.pathname);
+      if (lo && contentLocks.value.get(lo.route)) {
+        goto(`/course/${currentCourse.value.courseId}`);
+        return;
+      }
+    }
+
     const elemPage = document.querySelector("#content-panel");
     if (elemPage && window.innerWidth >= 600) {
       elemPage.scrollIntoView({ behavior: "smooth", block: "start" });


### PR DESCRIPTION
## Summary

Introduces a client-side role-based access control (RBAC) system enabling lecturers to manage course content visibility at runtime. This is a foundational step toward giving course owners control over student progression — locking/unlocking topics, units, and individual learning objects, and gating capabilities like quizzes.

### How it works

- **Course ownership**: Course authors set `owner: github-login` and/or `lecturers: login1,login2` in their course `properties.yaml`. On load, the app compares these against the authenticated user's GitHub login to determine lecturer status.
- **Content locking**: Lecturers can toggle locks on cards and units via inline buttons or the Lecturer Panel sidebar. Students see locked content as greyed-out cards with a lock icon overlay — visible but not navigable. Direct URL navigation to locked content redirects to the course page.
- **Lock persistence**: Lock state is stored in a Supabase table (`tutors_content_locks`) with a localStorage fallback, so it works locally without Supabase and degrades gracefully.
- **Lecturer Panel**: A new sidebar accessible from the nav bar (visible only to lecturers) with three tabs:
  - **Locks** — tree of all lockable content with toggle controls
  - **Enrollment** — read-only view of the course whitelist and student list
  - **Access** — surfaces existing learning records and activity data

### Key design decisions

- **Purely client-side**: All role checks and lock enforcement happen in the browser. This is consistent with the existing access control model (`authLevel`, `whitelist`, `isPrivate` are all client-side today). No server-side API routes or Supabase RLS.
- **localStorage fallback**: The RBAC service stores lock state in localStorage when Supabase is unavailable, enabling local development and testing without any backend setup.
- **Dev mode auto-lecturer**: When running `npm run dev` and no `owner`/`lecturers` is configured, a dev lecturer identity is auto-created. Press `L` to toggle between lecturer and student views for testing.

### New files
- `src/lib/services/rbac/` — types, lock management service, re-exports
- `src/lib/ui/navigators/buttons/LecturerButton.svelte` — nav bar sidebar trigger
- `src/lib/ui/learning-objects/content/LecturerPanel.svelte` — sidebar panel with locks/enrollment/analytics

### Modified files
- `runes.svelte.ts` — `isLecturer`, `courseLecturers`, `contentLocks` runes
- `lo-tree.ts` — lecturer extraction from course properties
- `(course-reader)/+layout.svelte` — lecturer computation, lock loading, route guard
- `supabase-client.ts` — lock CRUD and learning records query
- `Cards.svelte`, `Units.svelte` — lock overlay and toggle UI
- `MainNavigator.svelte` — conditional LecturerButton
- All 4 icon theme files — lock/unlock/lecturer icons
- `keyboard-shortcuts.ts`, `en.ts`, `TutorsShell.svelte` — L shortcut for dev view toggle

## Supabase table required

```sql
CREATE TABLE tutors_content_locks (
  course_id TEXT NOT NULL,
  lo_route TEXT NOT NULL,
  locked BOOLEAN NOT NULL DEFAULT true,
  locked_by TEXT NOT NULL,
  locked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  PRIMARY KEY (course_id, lo_route)
);
```

The feature degrades gracefully without this table (uses localStorage only).

## Test plan

- [ ] Set `owner: your-github-login` in a test course's `properties.yaml`
- [ ] Log in with matching GitHub account — LecturerButton appears in nav
- [ ] Toggle locks on cards via inline toggle or Lecturer Panel
- [ ] Verify locked cards appear greyed out with lock icon for students
- [ ] Verify direct URL navigation to locked LOs redirects to course page
- [ ] Verify locks persist across page refresh (localStorage)
- [ ] Dev mode: press `L` to toggle lecturer/student view
- [ ] Verify no build errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related

Tracks production hardening in #1103