### PR TITLE
Add custom Tessl tiles for Tutors platform architecture

### DIFF
--- a/.tessl/tiles/tessl/tutors-architecture/docs/authentication.md
+++ b/.tessl/tiles/tessl/tutors-architecture/docs/authentication.md
@@ -1,0 +1,85 @@
+# Authentication
+
+Tutors uses Auth.js (formerly NextAuth) with the SvelteKit adapter for GitHub OAuth authentication.
+
+## Configuration
+
+Defined in `src/hooks.server.ts`:
+
+```typescript
+SvelteKitAuth({
+  providers: [GitHub({ clientId, clientSecret })],
+  session: { strategy: "jwt", maxAge: 365 * 24 * 60 * 60 }, // 1-year sessions
+  callbacks: {
+    jwt({ token, profile }) {
+      if (profile) token.login = profile.login; // GitHub username
+      return token;
+    },
+    session({ session, token }) {
+      session.user.login = token.login; // Expose login in client session
+      return session;
+    }
+  }
+});
+```
+
+Three server handles chained via `sequence()`:
+1. **`localeHandle`** — reads locale from cookie, sets `event.locals.locale`
+2. **`securityHeaders`** — adds `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`
+3. **`authInitHandle`** — Auth.js GitHub OAuth
+
+## Session Flow
+
+1. `src/routes/+layout.server.ts` calls `locals.auth()` → extracts session
+2. Returns `{ loggedIn, user: TutorsId, locale }` to all pages
+3. `src/routes/+layout.svelte` receives session data:
+   - If user exists, calls `tutorsConnectService.reconnect(user)` → switches to Supabase profile, restores sentiment/share status
+   - Sets `tutorsId` global rune
+
+## TutorsId
+
+The client-side user identity:
+
+```typescript { .api }
+type TutorsId = {
+  name: string;    // Display name
+  login: string;   // GitHub username
+  email: string;
+  image: string;   // Avatar URL
+  share: string;   // Presence sharing status
+  sentiment: string; // Current sentiment
+};
+```
+
+## Sign In / Sign Out
+
+```typescript
+import { signIn, signOut } from "@auth/sveltekit/client";
+
+// Sign in with GitHub
+signIn("github");
+
+// Sign out
+signOut();
+```
+
+The auth page (`src/routes/(auth)/auth/`) displays a `SigninWithGithub` button and `TutorsTerms` component.
+
+## Anonymous Mode
+
+When `PUBLIC_ANON_MODE=TRUE`:
+- Auth UI is hidden (no sign-in button)
+- Supabase client is not initialized
+- Analytics and presence tracking are disabled
+- Profile uses `localStorageProfile` only
+
+## Whitelist / Enrollment
+
+Courses can restrict access via enrollment:
+
+```typescript
+// course.enrollment.whitelist contains GitHub usernames
+tutorsConnectService.checkWhiteList();
+```
+
+If the course has an enrollment whitelist and the authenticated user's GitHub login is not in it, they are redirected to the auth page. The enrollment data comes from the course's front matter properties.

--- a/.tessl/tiles/tessl/tutors-architecture/docs/data-flow.md
+++ b/.tessl/tiles/tessl/tutors-architecture/docs/data-flow.md
@@ -1,0 +1,55 @@
+# Data Flow
+
+## Course Loading Pipeline
+
+The primary data flow: user navigates to a course URL → route loader fetches and decorates course JSON → Svelte renders the content.
+
+### Step-by-Step
+
+1. **Navigation**: User navigates to `/course/{courseId}` (or any course-reader route)
+2. **Route loader**: `+page.ts` calls `courseService.readCourse(courseId, fetch)`
+3. **Cache check**: `getOrLoadCourse()` checks the `courses` Map — returns immediately on hit
+4. **URL resolution**: `determineCourseUrl()` normalizes the courseId:
+   - Netlify domains → used as-is
+   - `localhost` URLs → parsed directly
+   - Plain IDs → `{courseId}.netlify.app`
+5. **Fetch**: `fetch({protocol}{courseUrl}/tutors.json)` retrieves the full course JSON
+6. **Tree decoration**: `decorateCourseTree(course, courseId, courseUrl)`:
+   - Injects `courseUrl` into all Lo routes, images, PDFs (replaces `{{COURSEURL}}` placeholders)
+   - Recursively decorates via `decorateLoTree()` — sets parent references, loads icons from frontMatter, builds breadcrumb chains
+   - Converts `contentMd` → `contentHtml` via markdown-it (except labs/notes/notebooks which defer)
+   - Extracts `panels` and `units` from composite Los via `getPanels()` and `getUnits()`
+   - Builds `course.loIndex` (Map<route, Lo>) and `course.topicIndex` (Map<route, Topic>)
+   - Runs `loadPropertyFlags()`, `createCompanions()`, `createWalls()`, `initCalendar()`
+7. **Caching**: Course stored in `courseService.courses` Map
+8. **Rune update**: `currentCourse.value` and `currentLo.value` set — triggers Svelte reactivity
+9. **Rendering**: Page component receives decorated course/Lo data via `data` props
+
+### Lab Loading
+
+Labs add an extra step for markdown conversion:
+
+1. `courseService.readLab(courseId, labId, fetch)` loads the course
+2. Creates a `LiveLab` instance (implements `LabService`)
+3. `markdownService.convertLabToHtml(course, lab)` processes each `LabStep`:
+   - Converts `contentMd` → `contentHtml` with Shiki syntax highlighting
+   - Runs URL `filter()` to rewrite relative paths to CDN URLs
+4. LiveLab builds navbar HTML, caches step content in `chaptersHtml` Map
+5. LiveLab cached in `courseService.labs` Map
+
+### Note Loading
+
+1. `courseService.readLo(courseId, noteId, fetch)` loads the course
+2. If note not in `courseService.notes` cache:
+   - `markdownService.convertNoteToHtml(course, note)` converts markdown
+3. Note cached in `courseService.notes` Map
+
+## Analytics Event Flow
+
+On every navigation within the course-reader:
+
+1. Course-reader layout's `$effect` detects page change
+2. Calls `tutorsConnectService.learningEvent(page.params)`
+3. `analyticsService.reportPageLoad(course, lo, student)` → Supabase `learning_records` upsert
+4. `presenceService.sendLoEvent(course, lo, student)` → PartyKit broadcast + Supabase `tutors-connect-latest` upsert
+5. Every 30 seconds, timer calls `updateLearningRecordsDuration()` and `updateCalendarDuration()`

--- a/.tessl/tiles/tessl/tutors-architecture/docs/external-integrations.md
+++ b/.tessl/tiles/tessl/tutors-architecture/docs/external-integrations.md
@@ -1,0 +1,88 @@
+# External Integrations
+
+Tutors integrates with several external services for data persistence, real-time communication, and content delivery.
+
+## Supabase
+
+PostgreSQL database via Supabase client. Initialized in `src/lib/services/community/utils/supabase-client.ts`.
+
+### Tables
+
+| Table | Purpose | Key Columns |
+|---|---|---|
+| `learning_records` | Per-student per-Lo interaction tracking | `course_id`, `student_id`, `lo_id`, `duration`, `count`, `type`, `date_last_accessed` |
+| `calendar` | Per-student per-course daily time tracking | `id` (YYYY-MM-DD), `studentid`, `courseid`, `timeactive`, `pageloads` |
+| `tutors-connect-users` | Student profiles | `github_id` (PK), `full_name`, `avatar_url`, `email`, `sentiment`, `online_status` |
+| `tutors-connect-profiles` | Course visit history per user | `github_id`, JSON blob of `CourseVisit[]` |
+| `tutors-connect-courses` | Course catalogue entries | `course_id`, `visited_at`, `visit_count`, `course_record` |
+| `tutors-connect-latest` | Latest Lo snapshot per student per course | `course_id`, `student_id`, `payload`, `received_at` |
+
+### RPC Functions
+
+- `get_count_learning_records(field_name, course_base, user_name, lo_key)` — returns increment count for learning records
+- `increment_calendar(field_name, row_id, student_id_value, course_id_value)` — increments a calendar field atomically
+
+### Key Operations
+
+```typescript { .api }
+// Supabase client (not initialized in anonymous mode)
+const supabase: SupabaseClient;
+
+function storeStudentCourseLearningObjectInSupabase(course, loid, lo, student): Promise<void>;
+function updateLearningRecordsDuration(courseId, studentId, loId): Promise<void>;
+function updateCalendarDuration(id, studentId, courseId): Promise<void>;
+function addOrUpdateStudent(student: TutorsId): Promise<void>;
+function getTutorsConnectUserSentiment(githubId): Promise<string | null>;
+function updateTutorsConnectUserSentiment(githubId, sentiment): Promise<void>;
+function upsertTutorsConnectLatestLo(loRecord): Promise<void>;
+function getTutorsConnectLatestLosByCourseId(courseId): Promise<TutorsConnectLatestRow[]>;
+```
+
+## PartyKit
+
+WebSocket-based real-time communication for student presence.
+
+### Rooms
+
+| Room ID | Purpose |
+|---|---|
+| `tutors-all-course-access` | Global room — receives events from all courses |
+| `{courseId}` | Per-course room — receives events for a specific course |
+
+### Message Format
+
+JSON-serialized `LoRecord` containing course info, Lo route/title, and student identity.
+
+### Connection Pattern
+
+```typescript
+// Global connection (for /live page)
+presenceService.connectToAllCourseAccess();
+
+// Course-specific connection
+presenceService.startPresenceListener(courseId);
+```
+
+## Course Content CDN
+
+Courses are hosted as static JSON on Netlify:
+
+- **URL pattern**: `{courseId}.netlify.app/tutors.json`
+- **Content**: Full course tree as JSON, including all Lo metadata and markdown content
+- **Assets**: Images, PDFs, and archives served from the same origin
+
+## tutors-time-lib
+
+Separate analytics library (`@tutors/tutors-time-lib`). Initialized in `src/hooks.client.ts` with Supabase credentials. Provides the analytics dashboard UI for the `/time/[courseid]` route.
+
+## Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key |
+| `PUBLIC_ANON_MODE` | `"TRUE"` disables auth, analytics, presence |
+| `PUBLIC_PARTY_KIT_COURSE_URL` | PartyKit server URL |
+| `AUTH_SECRET` | Auth.js session encryption secret |
+| `AUTH_GITHUB_ID` | GitHub OAuth app client ID |
+| `AUTH_GITHUB_SECRET` | GitHub OAuth app client secret |

--- a/.tessl/tiles/tessl/tutors-architecture/docs/index.md
+++ b/.tessl/tiles/tessl/tutors-architecture/docs/index.md
@@ -1,0 +1,71 @@
+# Tutors Architecture
+
+Tutors is an open-source learning experience platform built as a SvelteKit front-end that renders structured educational content fetched from external CDN-hosted JSON. The application is fully client-side rendered (SSR disabled on course routes) and follows a service-oriented architecture with clear separation between services, UI components, and routing.
+
+## Package Information
+
+- **Package Name**: tutors
+- **Version**: 15.2.0
+- **Framework**: SvelteKit 2.x with Svelte 5 (runes)
+- **Language**: TypeScript 6.x
+- **Styling**: Tailwind CSS 4.x with Skeleton UI 4.x
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | SvelteKit 2, Svelte 5 |
+| Styling | Tailwind CSS 4, Skeleton UI 4 |
+| State | Svelte 5 runes (`$state`) |
+| Auth | Auth.js (GitHub OAuth) |
+| Database | Supabase (PostgreSQL) |
+| Real-time | PartyKit (WebSockets) |
+| Content | CDN-hosted JSON (Netlify) |
+| Markdown | markdown-it + Shiki + Mermaid |
+| PDF | PDF.js, Adobe DC View, Marp |
+| Model lib | @tutors/tutors-model-lib (via JSR) |
+
+## Project Structure
+
+```
+src/
+  lib/
+    runes.svelte.ts          — Global reactive state
+    services/
+      course/                — Course loading, caching, lab/notebook navigation
+      community/             — Analytics, presence, catalogue
+      connect/               — Auth, profiles, sentiment
+      markdown/              — Markdown-to-HTML pipeline
+      themes/                — Visual themes, layouts, icons
+      i18n/                  — Internationalization (5 locales)
+      a11y/                  — Keyboard shortcuts, reduced motion
+    ui/
+      TutorsShell.svelte     — App shell (header/main/footer)
+      components/            — Shared UI components
+      learning-objects/      — Content renderers, layout, structure
+      navigators/            — Navigation bars, buttons, titles
+      time/                  — Analytics dashboard components
+    types/                   — App-level type extensions
+    utils/                   — Utilities (sanitize, etc.)
+  routes/
+    (auth)/                  — Login, course-specific auth
+    (home)/                  — Landing page
+    (course-reader)/         — All course content routes (SSR=false)
+    (live)/                  — Real-time presence views, catalogue
+```
+
+## Architecture Principles
+
+- **Service singletons**: Each service is a module-level `const` object implementing a typed interface, re-exported from `index.ts`
+- **Map-based caching**: Courses, labs, notes, and notebooks cached in `Map<string, T>` instances within services
+- **Svelte 5 runes**: All reactive state uses the `rune<T>()` wrapper pattern — no Svelte stores
+- **CDN-first content**: Courses are static JSON hosted on Netlify, fetched and decorated at runtime
+- **Lo-tree decoration**: Raw course JSON is transformed via `decorateCourseTree()` — injecting URLs, building indexes, converting markdown
+- **Lazy content loading**: Labs, notes, and notebooks defer HTML conversion until first view
+
+## Capabilities
+
+- [Data Flow](data-flow.md) — Course loading pipeline from CDN fetch to rendered page
+- [State Management](state-management.md) — The `rune()` pattern, global runes, service-level state
+- [External Integrations](external-integrations.md) — Supabase, PartyKit, tutors-time-lib, environment variables
+- [Authentication](authentication.md) — Auth.js GitHub OAuth, sessions, anonymous mode, whitelist

--- a/.tessl/tiles/tessl/tutors-architecture/docs/state-management.md
+++ b/.tessl/tiles/tessl/tutors-architecture/docs/state-management.md
@@ -1,0 +1,79 @@
+# State Management
+
+Tutors uses Svelte 5 runes for all reactive state. There are no Svelte stores — the entire codebase uses the `rune<T>()` wrapper pattern.
+
+## The rune() Factory
+
+Defined in `src/lib/runes.svelte.ts`:
+
+```typescript { .api }
+const rune = <T>(initialValue: T) => {
+  let _rune = $state(initialValue);
+  return {
+    get value() { return _rune; },
+    set value(v: T) { _rune = v; }
+  };
+};
+```
+
+This wraps `$state()` in a getter/setter object that can be exported from non-`.svelte` files and used reactively across the application.
+
+### Usage Pattern
+
+```typescript
+// In a service or module
+export const currentCourse = rune<Course | null>(null);
+
+// Reading (in a component or $effect)
+const title = currentCourse.value?.title;
+
+// Writing (from a service or loader)
+currentCourse.value = decoratedCourse;
+```
+
+## Global Runes
+
+All exported from `src/lib/runes.svelte.ts`:
+
+| Rune | Type | Default | Purpose |
+|---|---|---|---|
+| `currentCourse` | `Course \| null` | `null` | Active course object |
+| `currentLo` | `Lo \| null` | `null` | Active learning object |
+| `currentLabStepIndex` | `number` | `0` | Current step in lab view |
+| `tutorsId` | `TutorsId \| null` | `null` | Authenticated user identity |
+| `courseProtocol` | `string` | `"https://"` | Protocol for course URLs |
+| `hideMainNavigator` | `boolean` | `false` | Focus mode — hides top nav bar |
+| `shortcutsOverlayOpen` | `boolean` | `false` | Keyboard shortcuts overlay visibility |
+| `animationDelay` | `number` | `200` | Animation timing in milliseconds |
+| `adobeLoaded` | `boolean` | `false` | Adobe PDF embed SDK loaded state |
+
+## Service-Level State
+
+Each service maintains its own reactive state using the same `rune()` pattern or direct `$state()` in `.svelte.ts` files:
+
+- **ThemeService**: `layout: { value: LayoutType }`, `cardStyle: { value: CardStyleType }`, `lightMode`, `isSnowing`
+- **PresenceService**: `studentsOnline: { value: LoRecord[] }`
+- **LiveService**: `coursesOnline: { value: LoRecord[] }`, `studentsOnline: { value: LoRecord[] }`
+- **i18n**: `locale: { value: SupportedLocale }`
+- **LoRecord**: Class with `$state` fields for reactive presence data
+
+## Caching
+
+Services use plain `Map` instances for caching — not reactive, just data storage:
+
+| Service | Cache | Key | Value |
+|---|---|---|---|
+| CourseService | `courses` | courseId | Course |
+| CourseService | `labs` | labId | LabService |
+| CourseService | `notes` | noteId | Note |
+| CourseService | `notebooks` | notebookId | NotebookService |
+
+## Persistence
+
+| What | Where | When |
+|---|---|---|
+| Theme, layout, card style, code theme | `localStorage` | On change |
+| Locale | Cookie (`tutors-locale`) | On change |
+| Course visits (anonymous) | `localStorage` | On navigation |
+| Course visits (authenticated) | Supabase `tutors-connect-profiles` | On navigation |
+| User preferences (sentiment, share) | Supabase `tutors-connect-users` | On change |

--- a/.tessl/tiles/tessl/tutors-architecture/tile.json
+++ b/.tessl/tiles/tessl/tutors-architecture/tile.json
@@ -1,0 +1,6 @@
+{
+  "name": "tessl/tutors-architecture",
+  "version": "15.2.0",
+  "docs": "docs/index.md",
+  "summary": "Tutors platform architecture overview: SvelteKit app with service-layer pattern, Svelte 5 runes state management, CDN-hosted course JSON, and Supabase/PartyKit integrations."
+}

--- a/.tessl/tiles/tessl/tutors-content-types/docs/base-types.md
+++ b/.tessl/tiles/tessl/tutors-content-types/docs/base-types.md
@@ -1,0 +1,75 @@
+# Base Types
+
+## Lo
+
+The foundational type for all content in Tutors. Every learning object — from a full course to a single note — extends or implements `Lo`.
+
+```typescript { .api }
+type Lo = {
+  type: string;
+  id: string;
+  title: string;
+  summary: string;
+  contentMd: string;
+  contentHtml?: string;
+  route: string;
+  authLevel: number;
+  img: string;
+  imgFile: string;
+  icon?: IconType;
+  video: string;
+  videoids: VideoIdentifiers;
+  hide: boolean;
+  frontMatter: Properties;
+  parentLo?: Lo;
+  parentTopic?: Topic;
+  parentCourse?: Course;
+  breadCrumbs?: Lo[];
+  learningRecords?: Map<string, LearningRecord>;
+};
+```
+
+### Key Fields
+
+- **`type`**: Discriminator string — one of the 17 Lo types (e.g., `"lab"`, `"topic"`, `"course"`).
+- **`id`**: Unique identifier within the course, derived from the content folder name.
+- **`route`**: URL path used for navigation. Injected during `decorateCourseTree()` with the course URL replacing `{{COURSEURL}}` placeholders.
+- **`contentMd`**: Raw markdown source. Converted to `contentHtml` during tree decoration (except for labs/notes/notebooks which defer conversion).
+- **`authLevel`**: Access control level. `0` = public, higher values require authentication. Set via `frontMatter` properties.
+- **`img`** / **`imgFile`**: Display image URL and filename for cards/thumbnails.
+- **`icon`**: Optional Iconify icon override from frontMatter.
+- **`hide`**: When `true`, the Lo is excluded from navigation and display.
+- **`frontMatter`**: A `Properties` instance containing key-value pairs from the content's YAML front matter.
+- **`parentLo`** / **`parentTopic`** / **`parentCourse`**: Back-references set during tree decoration for navigation and breadcrumb building.
+
+## LabStep
+
+A single step within a lab. Labs contain an ordered array of these.
+
+```typescript { .api }
+type LabStep = {
+  title: string;
+  shortTitle: string;
+  contentMd: string;
+  contentHtml?: string;
+  route: string;
+  id: string;
+  parentLo?: Lab;
+  type: string;
+};
+```
+
+- **`shortTitle`**: Abbreviated title used in the lab step navbar.
+- **`contentMd`** / **`contentHtml`**: Each step has its own markdown content, converted to HTML when the lab is loaded.
+
+## Properties
+
+Dynamic property collection for front matter. Uses a string index signature.
+
+```typescript { .api }
+class Properties {
+  [key: string]: string;
+}
+```
+
+Common property keys used in courses: `credits`, `auth`, `icon`, `hide`, `order`, `videoid`, `whitelist`, `enrollment`, `companions`, `calendar`, `llm`, `footer`, `ignorepin`, `pdforientation`, `defaultpdfreader`, `arevideos hidden`, `arelabstepsautonumbered`.

--- a/.tessl/tiles/tessl/tutors-content-types/docs/composite-types.md
+++ b/.tessl/tiles/tessl/tutors-content-types/docs/composite-types.md
@@ -1,0 +1,128 @@
+# Composite Types
+
+Composite types are learning objects that contain child Los. They form the structural hierarchy of a course.
+
+## Composite
+
+Base for all container types. Extends `Lo` with child collections.
+
+```typescript { .api }
+type Composite = Lo & {
+  toc: Lo[];
+  los: Lo[];
+  panels: Panels;
+  units: Units;
+};
+```
+
+- **`toc`**: Table of contents — flattened list of child Los for navigation.
+- **`los`**: Direct child learning objects.
+- **`panels`**: Extracted panel-style Los (videos, talks, notes, podcasts) displayed prominently at the top.
+- **`units`**: Extracted units, sides, and remaining standard Los for structured display.
+
+## Panels
+
+Collection of panel-style learning objects extracted from a composite's children.
+
+```typescript { .api }
+type Panels = {
+  panelVideos: PanelVideo[];
+  panelTalks: PanelTalk[];
+  panelNotes: PanelNote[];
+  panelPodcasts: Podcast[];
+};
+```
+
+Panel Los are displayed as prominent cards at the top of a topic or unit page, separated from the standard card grid.
+
+## Units
+
+Structural groupings within a composite.
+
+```typescript { .api }
+type Units = {
+  units: Unit[];
+  sides: Side[];
+  standardLos: Lo[];
+};
+```
+
+- **`units`**: Primary content groupings displayed in the main column.
+- **`sides`**: Secondary content displayed in a sidebar column when present.
+- **`standardLos`**: Remaining Los not categorized as units or sides.
+
+## Course
+
+Top-level container. Extends `Composite` with course-wide metadata, indexes, and configuration.
+
+```typescript { .api }
+type Course = Composite & {
+  type: "course";
+  courseId: string;
+  courseUrl: string;
+  topicIndex: Map<string, Topic>;
+  loIndex: Map<string, Lo>;
+  walls?: Lo[][];
+  wallMap?: Map<string, Lo[]>;
+  properties: Properties;
+  calendar?: Properties;
+  enrollment?: Enrollment;
+  courseCalendar?: Calendar;
+  authLevel: number;
+  isPortfolio: boolean;
+  isPrivate: boolean;
+  llm: number;
+  pdfOrientation: string;
+  areVideosHidden: boolean;
+  areLabStepsAutoNumbered: boolean;
+  hasEnrollment: boolean;
+  hasCalendar: boolean;
+  defaultPdfReader: string;
+  footer: string;
+  ignorePin: string;
+  companions: IconNavBar;
+  wallBar: IconNavBar;
+};
+```
+
+### Key Course Fields
+
+- **`courseId`**: Identifier used in URLs and caching (e.g., `"reference-course"`).
+- **`courseUrl`**: CDN base URL where course JSON and assets are hosted.
+- **`topicIndex`**: Map from route strings to `Topic` objects for fast lookup.
+- **`loIndex`**: Map from route strings to any `Lo` for fast lookup by path.
+- **`walls`**: Auto-generated aggregations of Los by type (e.g., all labs, all talks) for wall views.
+- **`wallMap`**: Map from type string to Los of that type.
+- **`properties`**: Course-level front matter configuration.
+- **`companions`**: External links displayed in the secondary navigator (e.g., Slack, Zoom, GitHub).
+- **`wallBar`**: Navigation icons for wall views (filtered by which types exist in the course).
+
+## Topic
+
+A major section within a course. Contains units, sides, and panel Los.
+
+```typescript { .api }
+type Topic = Composite & {
+  type: "topic";
+};
+```
+
+## Unit
+
+A grouping within a topic. Contains labs, talks, notes, and other simple Los.
+
+```typescript { .api }
+type Unit = Composite & {
+  type: "unit";
+};
+```
+
+## Side
+
+A sidebar grouping within a topic. Rendered in a secondary column alongside units.
+
+```typescript { .api }
+type Side = Composite & {
+  type: "side";
+};
+```

--- a/.tessl/tiles/tessl/tutors-content-types/docs/index.md
+++ b/.tessl/tiles/tessl/tutors-content-types/docs/index.md
@@ -1,0 +1,70 @@
+# Tutors Content Types (Learning Objects)
+
+All content in the Tutors platform is represented as Learning Objects (Los). The type system is defined in `@tutors/tutors-model-lib` and forms the backbone of course structure, rendering, and navigation. Types split into two categories: composite types that contain child Los, and simple types that represent leaf content.
+
+## Package Information
+
+- **Package Name**: @tutors/tutors-model-lib
+- **Package Type**: npm (via JSR)
+- **Language**: TypeScript
+- **Installation**: `npm install npm:@jsr/tutors__tutors-model-lib`
+
+## Core Imports
+
+```typescript
+import type {
+  Lo, Course, Topic, Unit, Side, Lab, LabStep, Talk, Note,
+  Notebook, NotebookCell, Archive, Web, Github, Tutorial,
+  PanelNote, PanelTalk, PanelVideo, Podcast,
+  Composite, Panels, Units
+} from "@tutors/tutors-model-lib";
+
+import {
+  simpleTypes, loCompositeTypes, loTypes, isCompositeLo, preOrder, Properties
+} from "@tutors/tutors-model-lib";
+
+import type { LoType, LearningRecord } from "@tutors/tutors-model-lib";
+```
+
+## Type Hierarchy
+
+```
+Lo (base)
+  +-- Lab        (type: "lab",       adds los: LabStep[], pdf, pdfFile)
+  +-- Talk       (type: "talk",      adds pdf, pdfFile)
+  |     +-- PanelTalk  (type: "paneltalk")
+  +-- Archive    (type: "archive",   adds archiveFile?)
+  +-- Web        (type: "web")
+  +-- Github     (type: "github")
+  +-- Tutorial   (type: "tutorial",  adds pdf, pdfFile)
+  +-- Note       (type: "note")
+  +-- Notebook   (type: "notebook",  adds cells, kernelLanguage, kernelName)
+  +-- Podcast    (type: "podcast",   adds episode)
+  +-- PanelNote  (type: "panelnote")
+  +-- PanelVideo (type: "panelvideo")
+  +-- Composite  (adds toc, los, panels, units)
+        +-- Topic   (type: "topic")
+        +-- Unit    (type: "unit")
+        +-- Side    (type: "side")
+        +-- Course  (type: "course", adds courseId, courseUrl, indexes, properties, ...)
+```
+
+## Type Classification
+
+```typescript
+const simpleTypes = [
+  "note", "archive", "web", "github", "panelnote", "paneltalk",
+  "panelvideo", "podcast", "talk", "book", "lab", "tutorial", "notebook"
+];
+
+const loCompositeTypes = ["unit", "side", "topic", "course"];
+
+const loTypes = simpleTypes.concat(loCompositeTypes); // all 17 types
+```
+
+## Capabilities
+
+- [Base Types](base-types.md) — The `Lo` base type and its fields, `LabStep`, `Properties` class
+- [Composite Types](composite-types.md) — `Composite`, `Course`, `Topic`, `Unit`, `Side`, `Panels`, `Units`
+- [Simple Types](simple-types.md) — `Lab`, `Talk`, `Note`, `Notebook`, `Archive`, `Web`, `Github`, `Tutorial`, `PanelNote`, `PanelTalk`, `PanelVideo`, `Podcast`
+- [Type Utilities](type-utilities.md) — `isCompositeLo()`, `filterByType()`, `flattenLos()`, `preOrder`, `LearningRecord`, icon types, media types

--- a/.tessl/tiles/tessl/tutors-content-types/docs/simple-types.md
+++ b/.tessl/tiles/tessl/tutors-content-types/docs/simple-types.md
@@ -1,0 +1,185 @@
+# Simple Types
+
+Simple types are leaf learning objects — they contain content but no child Los (except `Lab` which contains `LabStep[]`).
+
+## Lab
+
+A step-by-step practical exercise. The primary hands-on content type.
+
+```typescript { .api }
+type Lab = Lo & {
+  type: "lab";
+  los: LabStep[];
+  pdf: string;
+  pdfFile: string;
+};
+```
+
+- **`los`**: Ordered array of `LabStep` objects, each with its own markdown content.
+- **`pdf`** / **`pdfFile`**: Optional PDF version of the lab content.
+- Labs are loaded lazily — markdown-to-HTML conversion happens when a lab is first viewed via `markdownService.convertLabToHtml()`.
+- Step navigation uses URL-based routing and keyboard arrow keys.
+
+## Talk
+
+A presentation or lecture, typically with a PDF slide deck.
+
+```typescript { .api }
+type Talk = Lo & {
+  type: "talk";
+  pdf: string;
+  pdfFile: string;
+};
+```
+
+- Rendered using one of four PDF viewers based on course configuration: `TalkClient` (default), `TalkMozilla` (PDF.js), `TalkAdobe` (Adobe DC), or `TalkMarp` (Marp slides).
+
+## Tutorial
+
+A text-based tutorial with optional PDF.
+
+```typescript { .api }
+type Tutorial = Lo & {
+  type: "tutorial";
+  pdf: string;
+  pdfFile: string;
+};
+```
+
+## Note
+
+A standalone markdown document.
+
+```typescript { .api }
+type Note = Lo & {
+  type: "note";
+};
+```
+
+- Notes are loaded lazily — markdown conversion is deferred until first view.
+
+## Notebook
+
+A Jupyter notebook rendered as interactive content.
+
+```typescript { .api }
+type Notebook = Lo & {
+  type: "notebook";
+  cells: NotebookCell[];
+  kernelLanguage: string;
+  kernelName: string;
+};
+```
+
+- **`cells`**: Array of notebook cells (markdown, code, raw) with their outputs.
+- **`kernelLanguage`**: Programming language of code cells (e.g., `"python"`).
+- Notebooks are loaded lazily and rendered with Shiki syntax highlighting for code cells.
+
+### NotebookCell
+
+```typescript { .api }
+type NotebookCell = {
+  cellType: "markdown" | "code" | "raw";
+  source: string;
+  sourceHtml?: string;
+  outputs: NotebookOutput[];
+  outputsHtml?: string;
+  executionCount: number | null;
+  metadata: Record<string, unknown>;
+  id: string;
+};
+```
+
+### NotebookOutput
+
+```typescript { .api }
+type NotebookOutput = {
+  outputType: "stream" | "execute_result" | "display_data" | "error";
+  text?: string;
+  data?: Record<string, string>;
+  traceback?: string[];
+  name?: string;
+  executionCount?: number | null;
+};
+```
+
+## Archive
+
+A downloadable file resource.
+
+```typescript { .api }
+type Archive = Lo & {
+  type: "archive";
+  archiveFile?: string;
+};
+```
+
+## Web
+
+An external web resource link.
+
+```typescript { .api }
+type Web = Lo & {
+  type: "web";
+};
+```
+
+## Github
+
+A GitHub repository link.
+
+```typescript { .api }
+type Github = Lo & {
+  type: "github";
+};
+```
+
+## Podcast
+
+A podcast episode.
+
+```typescript { .api }
+type Podcast = Lo & {
+  type: "podcast";
+  episode: PodcastEpisodeIdentifier;
+};
+```
+
+### PodcastEpisodeIdentifier
+
+```typescript { .api }
+type PodcastEpisodeIdentifier = {
+  service: string;
+  id: string;
+};
+```
+
+## PanelNote
+
+A note displayed in the panels section at the top of a topic/unit page.
+
+```typescript { .api }
+type PanelNote = Lo & {
+  type: "panelnote";
+};
+```
+
+## PanelTalk
+
+A talk displayed in the panels section. Extends `Talk` (not `Lo` directly), so it inherits `pdf` and `pdfFile`.
+
+```typescript { .api }
+type PanelTalk = Talk & {
+  type: "paneltalk";
+};
+```
+
+## PanelVideo
+
+A video displayed in the panels section.
+
+```typescript { .api }
+type PanelVideo = Lo & {
+  type: "panelvideo";
+};
+```

--- a/.tessl/tiles/tessl/tutors-content-types/docs/type-utilities.md
+++ b/.tessl/tiles/tessl/tutors-content-types/docs/type-utilities.md
@@ -1,0 +1,176 @@
+# Type Utilities
+
+Utility functions and types for working with the Lo type system.
+
+## Type Classification
+
+### simpleTypes
+
+```typescript { .api }
+const simpleTypes: string[] = [
+  "note", "archive", "web", "github", "panelnote", "paneltalk",
+  "panelvideo", "podcast", "talk", "book", "lab", "tutorial", "notebook"
+];
+```
+
+### loCompositeTypes
+
+```typescript { .api }
+const loCompositeTypes: string[] = ["unit", "side", "topic", "course"];
+```
+
+### loTypes
+
+Combined array of all 17 Lo type strings.
+
+```typescript { .api }
+const loTypes: string[] = simpleTypes.concat(loCompositeTypes);
+```
+
+### LoType
+
+Union type derived from `loTypes`.
+
+```typescript { .api }
+type LoType = (typeof loTypes)[number];
+```
+
+### isCompositeLo
+
+```typescript { .api }
+function isCompositeLo(lo: Lo): boolean
+```
+
+Returns `true` if `lo.type` is one of `"unit"`, `"side"`, `"topic"`, or `"course"`.
+
+## Ordering
+
+### preOrder
+
+Map defining display order for Lo types. Lower values appear first.
+
+```typescript { .api }
+const preOrder: Map<string, number> = new Map([
+  ["course", 0], ["unit", 1], ["side", 2], ["topic", 3],
+  ["talk", 4], ["tutorial", 5], ["book", 6], ["lab", 7],
+  ["note", 8], ["web", 9], ["github", 10], ["archive", 11],
+  ["panelnote", 12], ["paneltalk", 13], ["panelvideo", 14],
+  ["podcast", 15], ["notebook", 16]
+]);
+```
+
+## Traversal Utilities
+
+From `@tutors/tutors-model-lib/utils/lo-utils`:
+
+### flattenLos
+
+```typescript { .api }
+function flattenLos(los: Lo[]): Lo[]
+```
+
+Recursively flattens a nested Lo tree into a single array.
+
+### filterByType
+
+```typescript { .api }
+function filterByType(los: Lo[], type: string): Lo[]
+```
+
+Filters a flat Lo array to only include Los of the specified type.
+
+### sortLos
+
+```typescript { .api }
+function sortLos(los: Lo[]): Lo[]
+```
+
+Sorts Los using the `preOrder` map — composite types first, then simple types in defined order.
+
+### crumbs
+
+```typescript { .api }
+function crumbs(lo: Lo | undefined, los: Lo[]): Lo[]
+```
+
+Builds breadcrumb trail by walking up the `parentLo` chain.
+
+### loadIcon
+
+```typescript { .api }
+function loadIcon(lo: Lo): void
+```
+
+Reads `icon` property from `lo.frontMatter` and sets `lo.icon` as an `IconType` with type and color fields.
+
+## Supporting Types
+
+### LearningRecord
+
+Tracks student interaction with a learning object.
+
+```typescript { .api }
+interface LearningRecord {
+  date: Date;
+  pageLoads: number;
+  timeActive: number;
+}
+```
+
+### IconType
+
+```typescript { .api }
+type IconType = {
+  type: string;
+  color: string;
+};
+```
+
+### IconNav
+
+Navigation icon with link and tooltip.
+
+```typescript { .api }
+type IconNav = {
+  link: string;
+  type: string;
+  tip: string;
+  target: string;
+};
+```
+
+### IconNavBar
+
+Collection of navigation icons with visibility flag.
+
+```typescript { .api }
+type IconNavBar = {
+  show: boolean;
+  bar: IconNav[];
+};
+```
+
+### VideoIdentifier / VideoIdentifiers
+
+```typescript { .api }
+type VideoIdentifier = {
+  service: string;
+  id: string;
+  url?: string;
+  externalUrl?: string;
+};
+
+type VideoIdentifiers = {
+  videoid: string;
+  videoIds: VideoIdentifier[];
+};
+```
+
+### Calendar Types
+
+```typescript { .api }
+type WeekType = { title: string; type: string; date: string; dateObj: Date };
+type Calendar = { title: string; weeks: WeekType[]; currentWeek?: WeekType };
+type Student = { name: string; id: string };
+type Enrollment = { whitelist: string[]; students: Student[] };
+```

--- a/.tessl/tiles/tessl/tutors-content-types/tile.json
+++ b/.tessl/tiles/tessl/tutors-content-types/tile.json
@@ -1,0 +1,6 @@
+{
+  "name": "tessl/tutors-content-types",
+  "version": "15.2.0",
+  "docs": "docs/index.md",
+  "summary": "Tutors Learning Object (Lo) type system: base Lo type, composite types (Course, Topic, Unit, Side), and simple types (Lab, Talk, Note, Notebook, Archive, Web, Github, PanelNote, PanelTalk, PanelVideo, Podcast)."
+}

--- a/.tessl/tiles/tessl/tutors-routing/docs/course-reader-routes.md
+++ b/.tessl/tiles/tessl/tutors-routing/docs/course-reader-routes.md
@@ -1,0 +1,65 @@
+# Course Reader Routes
+
+All routes under `src/routes/(course-reader)/`. Every route has `export const ssr = false`.
+
+## Route Table
+
+| Route Pattern | Params | Load Function | Page Component |
+|---|---|---|---|
+| `/course/[courseid]` | `courseid` | `courseService.readCourse(courseid)` | `Composite` |
+| `/topic/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readTopic(courseid, pathname)` | `Composite` |
+| `/lab/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLab(courseid, pathname)` | `Context > Lab` |
+| `/talk/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLo(courseid, pathname)` | `Context > TalkClient` |
+| `/paneltalk/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLo(courseid, pathname)` | `Context > TalkClient` |
+| `/note/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLo(courseid, pathname)` | `Context > Note` |
+| `/video/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLo(courseid, videoId)` | `Context > Video` |
+| `/tutorial/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readLo(courseid, pathname)` | `Context > Note + TalkClient` |
+| `/notebook/[courseid]/[...loid]` | `courseid`, `loid` (rest) | `courseService.readNotebook(courseid, pathname)` | `Context > Notebook` |
+| `/wall/[type]/[courseid]` | `type`, `courseid` | `courseService.readWall(courseid, type)` | `Wall` |
+| `/search/[courseid]` | `courseid` | `courseService.readCourse(courseid)` | Search UI |
+| `/time/[courseid]` | `courseid` | `courseService.readCourse(courseid)` | HeatMaps + Tables |
+| `/llm/[courseid]` | `courseid` | `courseService.readCourse(courseid)` + `generateLlms()` | LLM links |
+
+## Component Wrapping Patterns
+
+### Composite routes (course, topic)
+
+```svelte
+<Composite composite={data.course} />
+```
+
+Composite renders: `SecondaryNavigator` + `Panels` + `Units` + `Cards`. No `Context` wrapper needed.
+
+### Content routes (lab, talk, note, video, notebook)
+
+```svelte
+<Context lo={data.lo}>
+  <ContentComponent ... />
+</Context>
+```
+
+`Context` wraps content pages — walks up `parentLo` to find the enclosing topic, then shows `SecondaryNavigator` + content + sticky `LoContextPanel` sidebar.
+
+### Lab-specific
+
+Lab routes hide the main navigator (`hideMainNavigator.value = true`) for a focused experience. Step navigation uses URL-based routing with arrow keys.
+
+### Talk variants
+
+The talk route renders different PDF viewers based on file type and course configuration:
+- `.marp` files → `TalkMarp` (Marp presentation renderer)
+- Default → `TalkClient` (client-side PDF viewer)
+- Mozilla option → `TalkMozilla` (PDF.js)
+- Adobe option → `TalkAdobe` (Adobe DC View)
+
+### Tutorial route
+
+Renders both a `Note` (markdown content) and optionally a `TalkClient` (if the tutorial has a PDF file).
+
+### Video route
+
+Handles query parameters for video start/end times. Resolves videoId from the URL path.
+
+### Wall route
+
+Aggregates all Los of a given type across the course. The `type` param matches Lo type strings (e.g., `lab`, `talk`, `note`).

--- a/.tessl/tiles/tessl/tutors-routing/docs/data-loading.md
+++ b/.tessl/tiles/tessl/tutors-routing/docs/data-loading.md
@@ -1,0 +1,82 @@
+# Data Loading
+
+## The +page.ts Pattern
+
+Every course-reader route follows this data loading pattern:
+
+```typescript
+// src/routes/(course-reader)/course/[courseid]/+page.ts
+import type { PageLoad } from "./$types";
+import { courseService } from "$lib/services/course";
+import { currentCourse, currentLo } from "$lib/runes.svelte";
+
+export const ssr = false;
+
+export const load: PageLoad = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  currentCourse.value = course;
+  currentLo.value = course;
+  return { course, lo: course };
+};
+```
+
+### Key Points
+
+- **SSR disabled**: All course-reader routes set `export const ssr = false` — content is rendered client-side only
+- **SvelteKit `fetch`**: The `fetch` function from the load context is passed to `courseService` so SvelteKit can track the request
+- **Rune updates**: Load functions set `currentCourse.value` and `currentLo.value` before returning — this triggers reactive updates across the UI
+- **Return data**: The returned object is available as `data` props in the `+page.svelte` component
+
+## Rest Parameters
+
+Routes like `/lab/[courseid]/[...loid]` use SvelteKit rest params. The `loid` captures the full nested path:
+
+```
+/lab/reference-course/topic-01-simple/unit-1/lab-01
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                      params.loid = "topic-01-simple/unit-1/lab-01"
+```
+
+The `pathname` from `url.pathname` is used to look up the Lo in `course.loIndex`.
+
+## Lab Step Navigation
+
+Labs use URL-based step navigation:
+
+```typescript
+// Initial load — activate first step
+const lab = await courseService.readLab(params.courseid, pathname, fetch);
+lab.setFirstPageActive();
+
+// URL with step — activate specific step
+if (url.searchParams.has("step")) {
+  lab.setActivePage(url.searchParams.get("step"));
+}
+```
+
+The `currentLabStepIndex` rune tracks the active step for keyboard navigation.
+
+## Caching Behavior
+
+`courseService.readCourse()` internally calls `getOrLoadCourse()` which:
+1. Checks `courses` Map — returns immediately on cache hit
+2. On miss: fetches JSON, decorates tree, caches result
+3. Subsequent calls for the same `courseId` never re-fetch
+
+Labs, notes, and notebooks have their own caches:
+- `courseService.labs: Map<string, LabService>` — caches `LiveLab` instances
+- `courseService.notes: Map<string, Note>` — caches notes with HTML content
+- `courseService.notebooks: Map<string, NotebookService>` — caches `LiveNotebook` instances
+
+## Load Function Variants
+
+| Route | courseService Method | Returns |
+|---|---|---|
+| course | `readCourse(courseid)` | `Course` |
+| topic | `readTopic(courseid, pathname)` | `Lo` (Topic) |
+| lab | `readLab(courseid, pathname)` | `LabService` (LiveLab) |
+| notebook | `readNotebook(courseid, pathname)` | `NotebookService` (LiveNotebook) |
+| wall | `readCourse() + readWall(courseid, type)` | `Lo[]` |
+| talk/note/video/tutorial/paneltalk | `readLo(courseid, pathname)` | `Lo` |
+| search/time | `readCourse(courseid)` | `Course` |
+| llm | `readCourse(courseid)` + `generateLlms()` | `Course` + links |

--- a/.tessl/tiles/tessl/tutors-routing/docs/index.md
+++ b/.tessl/tiles/tessl/tutors-routing/docs/index.md
@@ -1,0 +1,43 @@
+# Tutors Routing
+
+Tutors uses SvelteKit file-based routing with four route groups. All course content routes disable SSR (`export const ssr = false`) for client-side rendering. Data loading delegates to the `courseService` singleton.
+
+## Route Groups
+
+| Group | URL Prefix | Purpose |
+|---|---|---|
+| `(auth)` | `/auth` | GitHub OAuth login flow |
+| `(home)` | `/` | Landing page, course visits |
+| `(course-reader)` | `/course`, `/lab`, `/talk`, etc. | All course content display |
+| `(live)` | `/live`, `/catalogue` | Real-time presence, course directory |
+
+## Root Layout Chain
+
+```
++layout.server.ts  →  Extracts auth session + locale from server
++layout.svelte     →  Reconnects user, initializes theme, sets locale
+  (course-reader)/+layout.svelte  →  Wraps in TutorsShell, starts analytics
+```
+
+## Data Loading Pattern
+
+Every course-reader route follows this pattern:
+
+```typescript
+// +page.ts
+export const ssr = false;
+
+export const load: PageLoad = async ({ params, fetch }) => {
+  const course = await courseService.readCourse(params.courseid, fetch);
+  // ... extract specific Lo from course
+  return { course, lo };
+};
+```
+
+The `courseService` handles caching — repeated loads for the same course return immediately from the Map cache.
+
+## Capabilities
+
+- [Route Groups](route-groups.md) — (auth), (home), (course-reader), (live) details
+- [Course Reader Routes](course-reader-routes.md) — Complete route table with patterns, loaders, components
+- [Data Loading](data-loading.md) — +page.ts loader pattern, rest params, rune updates

--- a/.tessl/tiles/tessl/tutors-routing/docs/route-groups.md
+++ b/.tessl/tiles/tessl/tutors-routing/docs/route-groups.md
@@ -1,0 +1,54 @@
+# Route Groups
+
+SvelteKit route groups (parenthesized directories) organize routes without adding URL segments.
+
+## (auth) — Authentication
+
+`src/routes/(auth)/auth/`
+
+| Route | Component | Purpose |
+|---|---|---|
+| `/auth` | `+page.svelte` | Login page with `SigninWithGithub` button and `TutorsTerms` |
+| `/auth/[courseid]` | `+page.svelte` | Course-specific auth redirect (stores courseId, then redirects to login) |
+
+## (home) — Landing Page
+
+`src/routes/(home)/`
+
+| Route | Component | Purpose |
+|---|---|---|
+| `/` | `+page.svelte` | Landing page showing `Welcome`, `CourseList` (recent visits), `Links`, `TutorsInfo` |
+
+Components:
+- `CourseList.svelte` — displays `CourseVisitCard` for each visited course
+- `CourseVisitCard.svelte` — card with course image, title, last visit date, favourite toggle
+- `Welcome.svelte` — greeting with user avatar (if authenticated)
+- `Links.svelte` — external links
+- `TutorsInfo.svelte` — platform information
+
+## (course-reader) — Course Content
+
+`src/routes/(course-reader)/`
+
+The primary route group containing all course content display routes. See [Course Reader Routes](course-reader-routes.md) for the complete table.
+
+### Layout
+
+`(course-reader)/+layout.svelte` wraps all children in `TutorsShell` and:
+- Starts the connect service timer (`startTimer()`)
+- Fires `tutorsConnectService.learningEvent(page.params)` on every navigation via `$effect`
+- On course change: runs `checkWhiteList()` and `courseVisit()`
+- After navigation: scrolls `#content-panel` into view and focuses `#main-content`
+- Sets `<title>` to `currentCourse.value.title`
+
+## (live) — Real-Time Views
+
+`src/routes/(live)/`
+
+| Route | Component | Purpose |
+|---|---|---|
+| `/catalogue` | `Catalogue.svelte` | Course directory with student/course counts |
+| `/live` | Live page | Platform-wide live activity (all courses, all students) |
+| `/live/[courseid]` | Live page | Course-specific live view (students currently in that course) |
+
+The live pages use `liveService.startGlobalPresenceService()` and `liveService.startCoursePresenceListener(courseId)` to display real-time student activity via PartyKit WebSockets.

--- a/.tessl/tiles/tessl/tutors-routing/tile.json
+++ b/.tessl/tiles/tessl/tutors-routing/tile.json
@@ -1,0 +1,6 @@
+{
+  "name": "tessl/tutors-routing",
+  "version": "15.2.0",
+  "docs": "docs/index.md",
+  "summary": "Tutors SvelteKit routing: four route groups (auth, home, course-reader, live), client-side rendering with SSR disabled, course-reader routes for all learning object types, and data loading via courseService."
+}

--- a/.tessl/tiles/tessl/tutors-services/docs/community-services.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/community-services.md
@@ -1,0 +1,121 @@
+# Community Services
+
+The community service area (`src/lib/services/community/`) handles analytics tracking, real-time presence, and course catalogue management. It communicates with Supabase for persistence and PartyKit for WebSocket-based real-time events.
+
+## AnalyticsService
+
+Records learning events (page loads, time spent) to Supabase.
+
+```typescript { .api }
+interface AnalyticsService {
+  loRoute: string;
+
+  learningEvent(course: Course, params: Record<string, unknown>, lo: Lo, student: TutorsId): void;
+  reportPageLoad(course: Course, lo: Lo, student: TutorsId): void;
+  updatePageCount(course: Course, lo: Lo, student: TutorsId): void;
+  updateLogin(courseId: string, session: any): void;
+}
+```
+
+- `learningEvent()` — called on every navigation from the course-reader layout's `$effect`
+- `reportPageLoad()` — upserts into Supabase `learning_records` table (course_id, student_id, lo_id, date, duration, count, type)
+- Duration updates run every 30 seconds via the connect service timer, incrementing `timeactive` in the `calendar` table
+
+### Supabase Tables Used
+
+| Table | Purpose | Key Columns |
+|---|---|---|
+| `learning_records` | Per-student per-Lo interaction tracking | `course_id`, `student_id`, `lo_id`, `duration`, `count`, `type` |
+| `calendar` | Per-student per-course daily time tracking | `id` (date), `studentid`, `courseid`, `timeactive`, `pageloads` |
+
+## PresenceService
+
+Real-time student tracking via PartyKit WebSockets.
+
+```typescript { .api }
+interface PresenceService {
+  studentsOnline: { value: LoRecord[] };
+  partyKitAll: PartySocket;
+  partyKitCourse: PartySocket;
+  studentEventMap: Map<string, LoRecord>;
+  listeningTo: string;
+
+  studentListener(event: MessageEvent): void;
+  sendLoEvent(course: Course, lo: Lo, student: TutorsId): void;
+  connectToAllCourseAccess(): void;
+  startPresenceListener(courseId: string): void;
+}
+```
+
+- **Global room**: `tutors-all-course-access` — receives events from all courses
+- **Course room**: `{courseId}` — receives events for a specific course
+- `sendLoEvent()` — serializes an `LoRecord` and sends to both PartyKit rooms + upserts to `tutors-connect-latest` in Supabase
+
+## LiveService
+
+Platform-wide activity monitoring for the `/live` pages.
+
+```typescript { .api }
+interface LiveService {
+  listeningForCourse: { value: string };
+  coursesOnline: { value: LoRecord[] };
+  studentsOnline: { value: LoRecord[] };
+  studentEventMap: Map<string, LoRecord>;
+  courseEventMap: Map<string, LoRecord>;
+  partyKitCourse: PartySocket;
+  listeningAll: boolean;
+
+  studentListener(event: MessageEvent): void;
+  courseListener(event: MessageEvent): void;
+  partyKitListener(event: MessageEvent): void;
+  startGlobalPresenceService(): void;
+  startCoursePresenceListener(courseId: string): void;
+}
+```
+
+## CatalogueService
+
+Manages the course directory.
+
+```typescript { .api }
+interface CatalogueService {
+  getCatalogue(): Promise<CatalogueEntry[]>;
+  getCatalogueCount(): Promise<number>;
+  getStudentCount(): Promise<number>;
+  pruneCatalogue(fetchFunction: typeof fetch): Promise<void>;
+  deleteCourses(courseIds: string[]): Promise<void>;
+}
+```
+
+- Queries `tutors-connect-courses` Supabase table for course entries
+- `pruneCatalogue()` — validates courses still exist by attempting to fetch their JSON, removes invalid entries
+
+## LoRecord
+
+Reactive class representing a student's current activity. Uses `$state` for all properties.
+
+```typescript { .api }
+class LoRecord {
+  courseId: string = $state("");
+  courseUrl: string = $state("");
+  courseTitle: string = $state("");
+  loRoute: string = $state("");
+  title: string = $state("");
+  img?: string = $state("");
+  icon?: IconType = $state(undefined);
+  isPrivate: boolean = $state(false);
+  user?: LoUser = $state(undefined);
+  type: string = $state("");
+}
+```
+
+### LoUser
+
+```typescript { .api }
+interface LoUser {
+  fullName: string;
+  avatar: string;
+  id: string;
+  sentiment: string;
+}
+```

--- a/.tessl/tiles/tessl/tutors-services/docs/connect-service.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/connect-service.md
@@ -1,0 +1,120 @@
+# Connect Service
+
+The connect service (`src/lib/services/connect/`) manages authentication, user profiles, course visit history, and sentiment tracking.
+
+## TutorsConnectService Interface
+
+```typescript { .api }
+interface TutorsConnectService {
+  profile: ProfileStore;
+  intervalId: any;
+  anonMode: boolean;
+
+  connect(redirectStr: string): void;
+  reconnect(user: TutorsId): void;
+  disconnect(redirectStr: string): void;
+  toggleShare(): void;
+  updateSentiment(sentiment: string): Promise<void>;
+  courseVisit(course: Course): void;
+  deleteCourseVisit(courseId: string): void;
+  getCourseVisits(): Promise<CourseVisit[]>;
+  favouriteCourse(courseId: string): void;
+  unfavouriteCourse(courseId: string): void;
+  learningEvent(params: Record<string, string>): void;
+  startTimer(): void;
+  stopTimer(): void;
+  checkWhiteList(): void;
+}
+```
+
+## Authentication Flow
+
+1. User clicks sign-in → `connect()` calls `signIn("github")` from `@auth/sveltekit/client`
+2. GitHub OAuth via Auth.js, configured in `src/hooks.server.ts`:
+   - JWT strategy with 1-year sessions
+   - Profile callback exposes GitHub `login` username
+   - Session callback injects `token.login` into `session.user.login`
+3. On page load, `+layout.server.ts` calls `locals.auth()` → returns `{ loggedIn, user, locale }`
+4. `+layout.svelte` calls `reconnect(user)` which:
+   - Switches from `localStorageProfile` to `supabaseProfile`
+   - Restores sentiment and share status from Supabase
+   - Updates `tutorsId` global rune
+
+### Anonymous Mode
+
+When `PUBLIC_ANON_MODE=TRUE`:
+- Authentication UI is hidden
+- Analytics and presence tracking are disabled
+- Supabase client is not initialized
+
+## ProfileStore Interface
+
+Two implementations: `localStorageProfile` (default) and `supabaseProfile` (authenticated).
+
+```typescript { .api }
+interface ProfileStore {
+  courseVisits: CourseVisit[];
+
+  reload(): void;
+  save(): void;
+  logCourseVisit(course: Course): void;
+  favouriteCourse(courseId: string): void;
+  unfavouriteCourse(courseId: string): void;
+  deleteCourseVisit(courseId: string): void;
+  getCourseVisits(): Promise<CourseVisit[]>;
+}
+```
+
+## Key Types
+
+### TutorsId
+
+```typescript { .api }
+type TutorsId = {
+  name: string;
+  login: string;
+  email: string;
+  image: string;
+  share: string;
+  sentiment: string;
+};
+```
+
+### CourseVisit
+
+```typescript { .api }
+type CourseVisit = {
+  id: string;
+  title: string;
+  img?: string;
+  icon?: IconType;
+  lastVisit: string;
+  credits: string;
+  visits?: number;
+  private: boolean;
+  favourite: boolean;
+};
+```
+
+### CourseSentimentId
+
+```typescript { .api }
+const COURSE_SENTIMENT_IDS = [
+  "neutral", "fine", "delighted", "confident",
+  "overwhelmed", "confused", "drained"
+] as const;
+
+type CourseSentimentId = (typeof COURSE_SENTIMENT_IDS)[number];
+```
+
+## Analytics Timer
+
+`startTimer()` sets a 30-second interval that:
+1. Calls `updateLearningRecordsDuration()` — increments duration in `learning_records` via Supabase RPC
+2. Calls `updateCalendarDuration()` — increments `timeactive` in `calendar` via Supabase RPC
+
+The timer is started in the course-reader layout and stopped on disconnect.
+
+## Whitelist
+
+`checkWhiteList()` validates the current user against `course.enrollment.whitelist`. If the course has an enrollment whitelist and the user's GitHub login is not in it, they are redirected to the auth page.

--- a/.tessl/tiles/tessl/tutors-services/docs/course-service.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/course-service.md
@@ -1,0 +1,115 @@
+# Course Service
+
+The course service (`src/lib/services/course/`) is the central data layer. It fetches course JSON from CDN, decorates the Lo tree, and provides cached access to all learning objects.
+
+## CourseService Interface
+
+```typescript { .api }
+interface CourseService {
+  courses: Map<string, Course>;
+  labs: Map<string, LabService>;
+  notes: Map<string, Note>;
+  notebooks: Map<string, NotebookService>;
+  courseUrl: any;
+
+  getOrLoadCourse(courseId: string, fetchFunction: typeof fetch): Promise<Course>;
+  readCourse(courseId: string, fetchFunction: typeof fetch): Promise<Course>;
+  readTopic(courseId: string, topicId: string, fetchFunction: typeof fetch): Promise<Lo>;
+  readLab(courseId: string, labId: string, fetchFunction: typeof fetch): Promise<LabService>;
+  readNotebook(courseId: string, notebookId: string, fetchFunction: typeof fetch): Promise<NotebookService>;
+  readWall(courseId: string, type: string, fetchFunction: typeof fetch): Promise<Lo[]>;
+  readLo(courseId: string, loId: string, fetchFunction: typeof fetch): Promise<Lo>;
+  refreshAllLabs(codeTheme: string): void;
+}
+```
+
+All methods call `getOrLoadCourse()` first, which checks the `courses` Map cache. On cache miss, it fetches `{protocol}{courseUrl}/tutors.json` and calls `decorateCourseTree()`.
+
+## Course Loading Flow
+
+1. Route `+page.ts` loader calls `courseService.readCourse(courseId, fetch)`
+2. `getOrLoadCourse()` resolves the course URL via `determineCourseUrl()`:
+   - Netlify domains: `{courseId}.netlify.app`
+   - Localhost URLs: parsed directly
+   - Plain IDs: `{courseId}.netlify.app` (default)
+3. Fetches `{protocol}{courseUrl}/tutors.json`
+4. `decorateCourseTree(course, courseId, courseUrl)`:
+   - Injects `courseUrl` into all routes, images, PDFs (replaces `{{COURSEURL}}` placeholders)
+   - Recursively calls `decorateLoTree()` — sets parent references, loads icons, builds breadcrumbs, converts markdown to HTML
+   - Labs, notes, and notebooks defer HTML conversion until first view
+   - Extracts panels and units from composite Los
+   - Builds `course.loIndex` (Map<route, Lo>) and `course.topicIndex` (Map<route, Topic>)
+   - Runs `loadPropertyFlags()`, `createCompanions()`, `createWalls()`, `initCalendar()`
+5. Course cached in `courses` Map, `currentCourse` rune updated
+
+## LabService Interface
+
+Manages step-by-step navigation within a lab.
+
+```typescript { .api }
+interface LabService {
+  course: Course;
+  lab: Lab;
+  url: string;
+  objectivesHtml: string;
+  currentChapterShortTitle: string;
+  currentChapterTitle: string;
+  navbarHtml: string;
+  horizontalNavbarHtml: string;
+  content: string;
+  chaptersHtml: Map<string, string>;
+  chaptersTitles: Map<string, string>;
+  steps: string[];
+  index: number;
+  autoNumber: boolean;
+  vertical: boolean;
+
+  convertMdToHtml(): void;
+  refreshStep(): void;
+  refreshNav(): void;
+  setCurrentChapter(step: string): void;
+  setFirstPageActive(): void;
+  setActivePage(step: string): void;
+  nextStep(): string;
+  prevStep(): string;
+}
+```
+
+- `setFirstPageActive()` — activates the first step (used on initial lab load)
+- `setActivePage(step)` — activates a specific step by URL segment
+- `nextStep()` / `prevStep()` — navigate between steps, returns the new step ID
+- `navbarHtml` / `horizontalNavbarHtml` — pre-rendered HTML for the step navigation bar
+
+## NotebookService Interface
+
+Manages cell navigation within a Jupyter notebook.
+
+```typescript { .api }
+interface NotebookService {
+  course: Course;
+  notebook: NotebookLo;
+  url: string;
+  cells: NotebookCell[];
+  cellCount: number;
+  activeCellIndex: number;
+  navbarHtml: string;
+  horizontalNavbarHtml: string;
+
+  setActiveCell(index: number): void;
+  nextCell(): number;
+  prevCell(): number;
+  isSolutionCell(cell: NotebookCell): boolean;
+  isExerciseCell(cell: NotebookCell): boolean;
+  getCellLabel(cell: NotebookCell, index: number): string;
+  getCellTypeIcon(cellType: string): string;
+  refreshNav(): void;
+}
+```
+
+## Caching
+
+Four in-memory Maps cache loaded content:
+- `courses: Map<string, Course>` — full course trees
+- `labs: Map<string, LabService>` — lab instances with converted HTML
+- `notes: Map<string, Note>` — notes with converted HTML
+- `notebooks: Map<string, NotebookService>` — notebook instances with converted cells

--- a/.tessl/tiles/tessl/tutors-services/docs/i18n-a11y.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/i18n-a11y.md
@@ -1,0 +1,108 @@
+# i18n and Accessibility
+
+## Internationalization
+
+The i18n service (`src/lib/services/i18n/`) provides translation support for 5 locales.
+
+### Supported Locales
+
+```typescript { .api }
+const SUPPORTED_LOCALES = ["en", "fr", "de", "it", "es"] as const;
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+```
+
+### API
+
+```typescript { .api }
+// Reactive locale state
+const locale: { value: SupportedLocale }; // default: "en"
+
+// Translation function — returns translated string for current locale
+function t(key: MessageKey): string;
+
+// Set locale — updates rune, cookie, and document.documentElement.lang
+function setLocale(newLocale: SupportedLocale): void;
+
+// Server-side: parse locale from cookie header
+function initLocaleFromCookie(cookieHeader?: string): SupportedLocale;
+```
+
+- `t()` looks up the key in the current locale's message map, falls back to English, then returns the raw key
+- Locale is persisted as a cookie and restored on the server via `initLocaleFromCookie()` in the locale handle hook
+- `MessageKey` is a union type of all valid translation keys, derived from the English message map
+
+### Usage
+
+```typescript
+import { t, setLocale, locale } from "$lib/services/i18n";
+
+// In a component
+const label = t("shortcuts.general"); // returns translated string
+setLocale("fr"); // switch to French
+```
+
+## Accessibility
+
+### Keyboard Shortcuts
+
+Defined in `src/lib/services/a11y/keyboard-shortcuts.ts`.
+
+```typescript { .api }
+type ShortcutContext = "general" | "lab" | "talk" | "notebook";
+
+interface ShortcutDefinition {
+  keys: string[];
+  descriptionKey: MessageKey;
+}
+
+interface ShortcutCategory {
+  titleKey: MessageKey;
+  context: ShortcutContext;
+  shortcuts: ShortcutDefinition[];
+}
+
+function getActiveCategories(loType?: string): ShortcutCategory[];
+```
+
+### Shortcut Categories
+
+**General** (always active):
+| Key | Action |
+|---|---|
+| `?` | Show keyboard shortcuts overlay |
+| `Esc` | Close overlay |
+| `F` | Toggle focus mode (hide/show main navigator) |
+| `T` | Scroll back to top |
+
+**Lab** (active on lab/step pages):
+| Key | Action |
+|---|---|
+| `→` / `↓` | Next step |
+| `←` / `↑` | Previous step |
+
+**Talk** (active on talk/paneltalk pages):
+| Key | Action |
+|---|---|
+| `→` | Next slide |
+| `←` | Previous slide |
+
+**Notebook** (active on notebook pages):
+| Key | Action |
+|---|---|
+| `→` / `↓` | Next cell |
+| `←` / `↑` | Previous cell |
+
+`getActiveCategories(loType)` returns the general category plus the context-specific category for the current Lo type. Maps: `"lab"/"step"` → lab context, `"talk"/"paneltalk"` → talk context, `"notebook"` → notebook context.
+
+### Reduced Motion
+
+```typescript { .api }
+// src/lib/services/a11y/reduced-motion.svelte.ts
+const prefersReducedMotion: { value: boolean };
+```
+
+Reactive rune that tracks the `prefers-reduced-motion` media query. Used to disable animations for users who prefer reduced motion.
+
+### Skip to Content
+
+`TutorsShell.svelte` includes a visually-hidden skip link (`<a href="#main-content">`) that becomes visible on focus, allowing keyboard users to bypass the navigation bar.

--- a/.tessl/tiles/tessl/tutors-services/docs/index.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/index.md
@@ -1,0 +1,53 @@
+# Tutors Services
+
+The Tutors service layer lives in `src/lib/services/` and follows a consistent singleton pattern across seven service areas. Each service has three files: `types.ts` (interface definition), `services/*.svelte.ts` (implementation), and `index.ts` (re-export of the singleton instance).
+
+## Service Architecture Pattern
+
+```typescript
+// types.ts — interface definition
+export interface FooService {
+  someMethod(arg: string): void;
+}
+
+// services/foo.svelte.ts — singleton implementation
+export const fooService: FooService = { ... };
+
+// index.ts — re-export
+export { fooService } from "./services/foo.svelte";
+```
+
+Services use the `.svelte.ts` extension when they use Svelte 5 runes (`$state`, `$derived`, `$effect`). All services are imported via `$lib/services/<name>`.
+
+## Core Imports
+
+```typescript
+import { courseService } from "$lib/services/course";
+import { analyticsService, presenceService, liveService, catalogueService } from "$lib/services/community";
+import { tutorsConnectService } from "$lib/services/connect";
+import { markdownService } from "$lib/services/markdown";
+import { themeService } from "$lib/services/themes";
+import { t, setLocale, locale } from "$lib/services/i18n";
+import { getActiveCategories } from "$lib/services/a11y/keyboard-shortcuts";
+```
+
+## Service Areas
+
+| Service | Location | Purpose |
+|---|---|---|
+| Course | `src/lib/services/course/` | Course loading, caching, lab/notebook navigation |
+| Community | `src/lib/services/community/` | Analytics, real-time presence, catalogue |
+| Connect | `src/lib/services/connect/` | Authentication, profiles, sentiment |
+| Markdown | `src/lib/services/markdown/` | Markdown-to-HTML conversion, syntax highlighting |
+| Themes | `src/lib/services/themes/` | Visual themes, layouts, card styles, icons |
+| i18n | `src/lib/services/i18n/` | Internationalization (5 locales) |
+| a11y | `src/lib/services/a11y/` | Keyboard shortcuts, reduced motion |
+
+## Capabilities
+
+- [Course Service](course-service.md) — CourseService, LabService, NotebookService, lo-tree decoration, caching
+- [Community Services](community-services.md) — AnalyticsService, PresenceService, LiveService, CatalogueService, LoRecord
+- [Connect Service](connect-service.md) — Authentication flow, ProfileStore, TutorsId, sentiment, timer
+- [Markdown Service](markdown-service.md) — Shiki highlighting, markdown-it plugins, Mermaid, Marp, notebook rendering
+- [Theme Service](theme-service.md) — Themes, layouts, card styles, icon libraries
+- [i18n and Accessibility](i18n-a11y.md) — Locales, translation, keyboard shortcuts, reduced motion

--- a/.tessl/tiles/tessl/tutors-services/docs/markdown-service.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/markdown-service.md
@@ -1,0 +1,73 @@
+# Markdown Service
+
+The markdown service (`src/lib/services/markdown/`) converts markdown content to HTML with syntax highlighting, diagram rendering, and presentation support.
+
+## MarkdownService Interface
+
+```typescript { .api }
+interface MarkdownService {
+  codeThemes: any;
+
+  setCodeTheme(theme: string): void;
+  convertLabToHtml(course: Course, lab: Lab, refreshOnly?: boolean): void;
+  convertNoteToHtml(course: Course, note: Note, refreshOnly?: boolean): void;
+  convertNotebookToHtml(course: Course, lo: Lo, refreshOnly?: boolean): void;
+}
+```
+
+- `convertLabToHtml()` — processes each `LabStep` in the lab, converting `contentMd` to `contentHtml` with Shiki highlighting and URL filtering
+- `convertNoteToHtml()` — converts the note's `contentMd` to `contentHtml`
+- `convertNotebookToHtml()` — processes each cell: markdown cells get markdown-it conversion, code cells get Shiki highlighting, outputs are rendered by type
+- `refreshOnly` flag — when `true`, re-renders HTML without re-fetching markdown (used when switching code themes)
+
+## Processing Pipeline
+
+### Base Markdown Processor
+
+Configured in `@tutors/tutors-model-lib` (`markdown-utils.ts`):
+- **markdown-it** with plugins: KaTeX (LaTeX math), anchors, TOC, emoji, sub/sup, mark, footnote, deflist
+- Custom plugins for video players and podcast embeds
+- `filter()` function rewrites relative image/archive paths to absolute CDN URLs
+
+### Syntax Highlighting
+
+**Shiki** code highlighter with:
+- **29 languages** supported (TypeScript, JavaScript, Python, Java, Go, Rust, C++, HTML, CSS, SQL, and more)
+- **7 themes**: github-light, github-dark, monokai, dracula, night-owl, one-dark-pro, catppuccin-latte
+- Copy-button transformer adds a clipboard button to code blocks
+- Theme persisted in `localStorage`
+
+### Mermaid Diagrams
+
+Fenced code blocks with language `mermaid` are rendered as `<div class="mermaid">` elements. Client-side Mermaid.js processes these on page load.
+
+### Marp Presentations
+
+Talks with `.marp` files use the `TalkMarp` component which renders Marp-formatted markdown as slide presentations. The renderer processes `---` delimiters as slide breaks and applies Marp themes.
+
+### URL Filtering
+
+The `filter()` function from `@tutors/tutors-model-lib` rewrites URLs in the converted HTML:
+- Relative image paths → absolute CDN URLs based on course URL
+- Archive download links → absolute CDN URLs
+- Handles image types: `png`, `jpg`, `jpeg`, `gif`, `svg`, `PNG`, `JPG`, `JPEG`, `GIF`, `SVG`
+
+## Notebook Rendering
+
+`convertNotebookToHtml()` processes each `NotebookCell`:
+
+| Cell Type | Processing |
+|---|---|
+| `markdown` | markdown-it conversion |
+| `code` | Shiki syntax highlighting (language from `kernelLanguage`) |
+| `raw` | Passed through as-is |
+
+### Notebook Outputs
+
+Each output is rendered by its `outputType`:
+
+| Output Type | Rendering |
+|---|---|
+| `stream` | Plain text display |
+| `execute_result` / `display_data` | Checks `data` for HTML, SVG, PNG, JPEG, LaTeX, or plain text (in priority order) |
+| `error` | Formatted traceback with ANSI color stripping |

--- a/.tessl/tiles/tessl/tutors-services/docs/theme-service.md
+++ b/.tessl/tiles/tessl/tutors-services/docs/theme-service.md
@@ -1,0 +1,109 @@
+# Theme Service
+
+The theme service (`src/lib/services/themes/`) manages visual appearance including themes, display modes, layouts, card styles, and icon libraries.
+
+## ThemeService Interface
+
+```typescript { .api }
+interface ThemeService {
+  themes: Theme[];
+  currentTheme: any;
+  layout: { value: LayoutType };
+  lightMode: any;
+  cardStyle: { value: CardStyleType };
+  isSnowing: boolean;
+
+  initDisplay(forceTheme?: string, forceMode?: string): void;
+  setDisplayMode(mode: string): void;
+  toggleDisplayMode(): void;
+  setTheme(theme: string): void;
+  setLayout(layout: string): void;
+  toggleLayout(): void;
+  setCardStyle(style: string): void;
+  getIcon(type: string): IconType;
+  addIcon(type: string, icon: IconType): void;
+  getTypeColour(type: string): string;
+  eventTrigger(): void;
+}
+```
+
+## Themes
+
+Seven built-in themes, each with its own icon library mapping Lo types to Iconify icons with colors:
+
+| Theme | Description |
+|---|---|
+| `tutors` | Default theme |
+| `classic` | Classic Tutors appearance |
+| `dyslexia` | Accessibility-focused for dyslexic readers |
+| `terminus` | Terminal/hacker aesthetic |
+| `rose` | Rose-toned theme |
+| `cerberus` | Dark theme |
+| `easter` | Seasonal theme with Easter icons |
+
+Themes use the Skeleton UI theming system and are applied via CSS classes.
+
+## Icon Libraries
+
+Each theme has an `IconLib` — a `Record<string, IconType>` mapping Lo type strings to icon definitions:
+
+```typescript { .api }
+type IconLib = Record<string, IconType>;
+type Theme = { name: string; icons: IconLib };
+type IconType = { type: string; color: string };
+```
+
+Icon libraries:
+- **FluentIconLib** — Microsoft Fluent icons (default for most themes)
+- **HeroIconLib** — Heroicons
+- **EasterIcons** — Easter-themed icons
+- **FestiveIcons** — Holiday/festive icons (triggers snow animation)
+
+`getIcon(type)` looks up the icon for a Lo type string (e.g., `"lab"`, `"talk"`, `"topic"`).
+`getTypeColour(type)` returns the color string for a Lo type.
+
+## Layouts
+
+```typescript { .api }
+type LayoutType = "expanded" | "compacted";
+```
+
+- **expanded** — full card display with images and summaries
+- **compacted** — condensed view, smaller cards
+
+## Card Styles
+
+```typescript { .api }
+type CardStyleType = "portrait" | "landscape" | "circular";
+```
+
+- **portrait** — vertical card with image on top
+- **landscape** — horizontal card with image on left
+- **circular** — compact card with circular image/icon
+
+## CardDetails
+
+The data structure passed to `Card.svelte` for rendering.
+
+```typescript { .api }
+interface CardDetails {
+  route: string;
+  title?: string;
+  type: string;
+  summary?: string;
+  summaryEx?: string;
+  icon?: IconType;
+  img?: string;
+  student?: LoUser;
+  video?: string;
+  metric?: string;
+}
+```
+
+## Display Mode
+
+Light/dark mode toggle. Persisted in `localStorage`. Applied via Skeleton UI's mode system (`modeCurrent`).
+
+## Festive Features
+
+`eventTrigger()` checks for seasonal dates and activates festive icons and snow animation (`isSnowing` flag).

--- a/.tessl/tiles/tessl/tutors-services/tile.json
+++ b/.tessl/tiles/tessl/tutors-services/tile.json
@@ -1,0 +1,6 @@
+{
+  "name": "tessl/tutors-services",
+  "version": "15.2.0",
+  "docs": "docs/index.md",
+  "summary": "Tutors service layer: singleton services for course loading (CourseService), community analytics (AnalyticsService, PresenceService, LiveService, CatalogueService), user connection (TutorsConnectService), markdown rendering (MarkdownService), theming (ThemeService), i18n, and accessibility."
+}

--- a/.tessl/tiles/tessl/tutors-ui/docs/content-renderers.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/content-renderers.md
@@ -1,0 +1,114 @@
+# Content Renderers
+
+Content renderers display the actual learning content. Located in `src/lib/ui/learning-objects/content/`.
+
+## Lab
+
+`content/lab/Lab.svelte` — step-based lab viewer.
+
+**Props:** `{ lab: LabService }`
+
+### Features
+- Displays lab objectives HTML at the top
+- Step navigation via sidebar navbar (vertical) or horizontal navbar
+- Arrow key navigation (left/up = previous, right/down = next)
+- Current step content rendered as HTML (pre-converted by `markdownService`)
+- Auto-numbering of steps when `course.areLabStepsAutoNumbered` is true
+- Hides main navigator for focused experience
+
+### Step Navigation
+- `lab.navbarHtml` — vertical step list (sidebar)
+- `lab.horizontalNavbarHtml` — horizontal step indicators
+- `lab.nextStep()` / `lab.prevStep()` — programmatic navigation
+- `currentLabStepIndex` rune tracks active step
+
+## Talk Variants
+
+Four PDF/presentation renderers, selected based on file type and course configuration:
+
+### TalkClient
+
+`content/talk/TalkClient.svelte` — default client-side PDF viewer.
+
+**Props:** `{ lo: Lo }`
+
+### TalkMozilla
+
+`content/talk/TalkMozilla.svelte` — Mozilla PDF.js viewer.
+
+**Props:** `{ lo: Lo }`
+
+Uses `pdfjs-dist` for rendering. Provides page navigation and zoom controls.
+
+### TalkAdobe
+
+`content/talk/TalkAdobe.svelte` — Adobe DC View embedded viewer.
+
+**Props:** `{ lo: Lo }`
+
+Uses the Adobe PDF Embed API. Requires the Adobe SDK to be loaded (`adobeLoaded` rune).
+
+### TalkMarp
+
+`content/talk/TalkMarp.svelte` — Marp presentation renderer.
+
+**Props:** `{ lo: Lo }`
+
+Renders Marp-formatted markdown as slide presentations. Processes `---` delimiters as slide breaks and applies Marp themes. Supports left/right arrow key navigation between slides.
+
+## Note
+
+`content/Note.svelte` — rendered markdown document.
+
+**Props:** `{ lo: Lo }`
+
+Displays `lo.contentHtml` (pre-converted from `contentMd` by `markdownService`). Supports Mermaid diagrams, KaTeX math, syntax-highlighted code blocks, and all markdown-it plugins.
+
+## Video
+
+`content/Video.svelte` — video player.
+
+**Props:** `{ lo: Lo }`
+
+Resolves video configuration from `lo.videoids` and renders the appropriate embed (YouTube, Vimeo, etc.). Supports query parameters for start/end times.
+
+## Notebook
+
+`content/notebook/Notebook.svelte` — Jupyter notebook viewer.
+
+**Props:** `{ notebook: NotebookService }`
+
+### Features
+- Cell navigation via sidebar navbar and arrow keys
+- Cell type indicators (markdown, code, raw)
+- Exercise/solution cell detection and labeling
+- Syntax-highlighted code cells via Shiki
+
+### Cell Components
+
+Located in `content/notebook/cells/`:
+
+| Component | Purpose |
+|---|---|
+| `NotebookCell.svelte` | Dispatcher — renders the appropriate cell type |
+| `NotebookMarkdownCell.svelte` | Rendered markdown content |
+| `NotebookCodeCell.svelte` | Syntax-highlighted code with outputs |
+| `NotebookRawCell.svelte` | Raw text display |
+| `NotebookExerciseCell.svelte` | Exercise prompt cell |
+| `NotebookSolutionCell.svelte` | Collapsible solution cell |
+
+### NotebookCodeEditor
+
+`content/notebook/NotebookCodeEditor.svelte` — displays code cell source with Shiki syntax highlighting. Shows execution count badge and cell outputs below.
+
+## Calendar
+
+`content/Calendar.svelte` — course calendar view.
+
+Displays the course schedule with week titles, dates, and current week highlighting.
+
+## Podcast
+
+`content/Podcast.svelte` — podcast episode player.
+
+Renders an embedded podcast player based on `lo.episode` (service and episode ID).

--- a/.tessl/tiles/tessl/tutors-ui/docs/index.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/index.md
@@ -1,0 +1,51 @@
+# Tutors UI Components
+
+The Tutors UI layer lives in `src/lib/ui/` and is organized into four directories: shared components, learning object renderers/layouts/structures, navigators, and analytics views. All components use Svelte 5 with `$props()`, `$derived()`, `$state()`, and `$effect()`.
+
+## Component Directory Structure
+
+```
+src/lib/ui/
+  TutorsShell.svelte                 — App shell (header/main/footer)
+  components/                        — Shared utility components
+  learning-objects/
+    content/                         — Content renderers (Lab, Talk, Note, etc.)
+    layout/                          — Layout components (Card, Cards, Panels, etc.)
+    structure/                       — Structural components (Composite, Context)
+  navigators/
+    MainNavigator.svelte             — Top app bar
+    SecondaryNavigator.svelte        — Per-page breadcrumb/companion bar
+    buttons/                         — Navigator button components
+    footers/                         — Footer components
+    titles/                          — Title components
+    tutors-connect/                  — Auth profile components
+  time/                              — Analytics dashboard components
+```
+
+## Core Layout
+
+```
+TutorsShell
+  ├── header: MainNavigator (toggleable via F key)
+  ├── main#main-content: route content
+  │     └── Composite (for course/topic routes)
+  │         ├── SecondaryNavigator
+  │         ├── Panels (panel videos/talks/notes/podcasts)
+  │         ├── Units (grouped content)
+  │         └── Cards (ungrouped content)
+  │     └── Context (for content routes: lab/talk/note/video/notebook)
+  │         ├── SecondaryNavigator
+  │         ├── Content renderer
+  │         └── LoContextPanel (sidebar)
+  ├── footer: Footer
+  ├── Back-to-top button (after 400px scroll)
+  └── KeyboardShortcutsOverlay (toggled by ?)
+```
+
+## Capabilities
+
+- [Shell and Navigation](shell-navigation.md) — TutorsShell, MainNavigator, SecondaryNavigator, buttons
+- [Structure Components](structure-components.md) — Composite, Context, LoContextTree, LoReference
+- [Layout Components](layout-components.md) — Card, Cards, Panels, Units, Wall
+- [Content Renderers](content-renderers.md) — Lab, Talk variants, Note, Video, Notebook, Calendar
+- [Utility Components](utility-components.md) — Icon, Image, Menu, Sidebar, LanguageSwitcher, KeyboardShortcuts

--- a/.tessl/tiles/tessl/tutors-ui/docs/layout-components.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/layout-components.md
@@ -1,0 +1,92 @@
+# Layout Components
+
+Layout components handle the visual arrangement of learning objects. Located in `src/lib/ui/learning-objects/layout/`.
+
+## Card
+
+`Card.svelte` — renders a single learning object as a card.
+
+**Props:** `{ cardDetails: CardDetails, cardLayout?: CardConfig }`
+
+### CardDetails
+
+```typescript { .api }
+interface CardDetails {
+  route: string;      // Navigation URL
+  title?: string;
+  type: string;       // Lo type (determines border color)
+  summary?: string;
+  summaryEx?: string;
+  icon?: IconType;
+  img?: string;
+  student?: LoUser;   // For presence cards
+  video?: string;
+  metric?: string;    // Analytics metric display
+}
+```
+
+### CardConfig
+
+```typescript { .api }
+type CardConfig = {
+  style: "portrait" | "landscape" | "circular";
+  layout: "expanded" | "compacted";
+};
+```
+
+### Variants
+
+- **Portrait** — vertical card, image on top, title and summary below
+- **Landscape** — horizontal card, image on left, content on right
+- **Circular** — compact card with circular image/icon
+
+Border colors are derived from `themeService.getTypeColour(cardDetails.type)` — each Lo type has a distinct color.
+
+## Cards
+
+`Cards.svelte` — renders a grid of `Card` components.
+
+**Props:** `{ los: Lo[], parentCourse?: Course }`
+
+- Maps each Lo to `CardDetails`
+- Applies the current layout (`expanded`/`compacted`) and card style (`portrait`/`landscape`/`circular`) from `themeService`
+- Supports pin-unlock: Los with `hide: true` can be revealed via `ignorePin` course property
+
+## Panels
+
+`Panels.svelte` — renders panel-style Los prominently at the top of a composite.
+
+**Props:** `{ panels: Panels }`
+
+Renders four groups in order:
+1. `panelVideos` — video cards (typically with embedded players)
+2. `panelTalks` — presentation cards
+3. `panelNotes` — note cards
+4. `panelPodcasts` — podcast cards
+
+Panel cards are typically displayed larger/more prominently than standard Cards.
+
+## Units
+
+`Units.svelte` — renders unit groupings within a composite.
+
+**Props:** `{ units: Units }`
+
+For each unit:
+- Renders the unit title/header
+- Renders its own `Panels` (if the unit has panel Los)
+- Renders its own `Cards` (for the unit's child Los)
+
+## Wall
+
+`Wall.svelte` — gallery/grid view for all Los of a specific type.
+
+**Props:** `{ los: Lo[], type: string }`
+
+Used on `/wall/[type]/[courseid]` routes. Displays all Labs, all Talks, all Notes, etc. in a filterable grid.
+
+## LoContextPanel
+
+`LoContextPanel.svelte` — sticky sidebar panel shown on content pages.
+
+Lists sibling Los within the same parent (topic/unit), allowing quick navigation between related content. Hidden on smaller screens.

--- a/.tessl/tiles/tessl/tutors-ui/docs/shell-navigation.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/shell-navigation.md
@@ -1,0 +1,94 @@
+# Shell and Navigation
+
+## TutorsShell
+
+`src/lib/ui/TutorsShell.svelte` — the app shell wrapping all course-reader routes.
+
+### Structure
+
+```svelte
+<div class="flex h-screen flex-col">
+  <a href="#main-content">Skip to content</a>   <!-- visible on focus -->
+  <header>
+    <MainNavigator />                            <!-- hidden when hideMainNavigator is true -->
+  </header>
+  <main id="main-content">
+    {@render children()}                         <!-- route content -->
+  </main>
+  <footer>
+    <Footer />                                   <!-- visible when viewport >= 800px height -->
+  </footer>
+  <button>Back to top</button>                   <!-- visible after 400px scroll -->
+  <KeyboardShortcutsOverlay />                   <!-- toggled by ? key -->
+</div>
+```
+
+### Global Keyboard Shortcuts
+
+Handled in `TutorsShell`:
+- `?` — toggle keyboard shortcuts overlay
+- `f` — toggle focus mode (hide/show `MainNavigator`)
+- `t` — scroll back to top
+
+## MainNavigator
+
+`src/lib/ui/navigators/MainNavigator.svelte` — the top application bar using Skeleton UI `AppBar`.
+
+### Slots
+
+| Position | Components |
+|---|---|
+| Lead | `InfoButton` (when course loaded) or `TutorsTitle` (landing) |
+| Headline | `CourseTitle` |
+| Trail | `CalendarButton`, `CourseSentimentButton`, `LlmsIndicator`, `TutorsTimeIndicator`, `SearchButton`, `LayoutMenu`, auth profile, `TocButton` |
+
+## SecondaryNavigator
+
+`src/lib/ui/navigators/SecondaryNavigator.svelte` — displayed within route pages below the main navigator.
+
+**Props:** `{ lo: Lo, parentCourse?: Course }`
+
+Contains:
+- `Breadcrumbs` — path trail from course → topic → unit → current Lo
+- `EditCoursButton` — link to course source (when available)
+- Companion `IconBar` — external links (Slack, Zoom, GitHub, etc.)
+- Wall `IconBar` — navigation to wall views (all labs, all talks, etc.)
+
+## Navigator Buttons
+
+All in `src/lib/ui/navigators/buttons/`:
+
+| Component | Purpose |
+|---|---|
+| `Breadcrumbs` | Navigation path trail |
+| `CalendarButton` | Link to course calendar (if course has calendar) |
+| `CourseSentimentButton` | Sentiment selector dropdown (7 sentiments) |
+| `EditCoursButton` | Link to edit course source |
+| `InfoButton` | Course info tooltip/panel |
+| `LlmsIndicator` | Link to LLM export page (if course has llm property) |
+| `OnlineButton` | Online students indicator |
+| `SearchButton` | Course content search |
+| `TocButton` | Table of contents sidebar toggle |
+| `TutorsTimeIndicator` | Link to time analytics page |
+
+## Titles
+
+| Component | Purpose |
+|---|---|
+| `CourseTitle` | Displays current course title in the app bar |
+| `TutorsTitle` | Displays "Tutors" branding on the landing page |
+
+## Footers
+
+| Component | Purpose |
+|---|---|
+| `Footer` | Bottom bar with `TutorsMessage` and `TutorsVersion` |
+| `TutorsMessage` | Customizable footer message from course properties |
+| `TutorsVersion` | App version display |
+
+## Auth Profile
+
+| Component | Purpose |
+|---|---|
+| `AnonProfile` | Sign-in button for unauthenticated users |
+| `ConnectedProfile` | User avatar, name, sign-out, share toggle for authenticated users |

--- a/.tessl/tiles/tessl/tutors-ui/docs/structure-components.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/structure-components.md
@@ -1,0 +1,75 @@
+# Structure Components
+
+Structure components define how learning objects are composed and presented. Located in `src/lib/ui/learning-objects/structure/`.
+
+## Composite
+
+`Composite.svelte` — renders any composite Lo (course, topic, unit).
+
+**Props:** `{ composite: Composite }`
+
+### Layout
+
+```
+SecondaryNavigator
+┌─────────────────────────────┬──────────────┐
+│ Main Column                 │ Side Column  │
+│  Panels                     │  (Side Los)  │
+│  Units                      │              │
+│  Cards                      │              │
+└─────────────────────────────┴──────────────┘
+```
+
+- Renders `SecondaryNavigator` with breadcrumbs and companion links
+- Renders `Panels` (panel videos, talks, notes, podcasts) at the top
+- Renders `Units` (each unit has its own Panels + Cards)
+- Renders `Cards` for any remaining standard Los
+- When `composite.units.sides` exist, uses a two-column layout with sticky sidebar
+
+## Context
+
+`Context.svelte` — wraps content pages (lab, talk, note, video, notebook).
+
+**Props:** `{ children: Snippet, lo: Lo }`
+
+### Layout
+
+```
+SecondaryNavigator
+┌─────────────────────────────┬──────────────────┐
+│ Content                     │ LoContextPanel   │
+│  (children snippet)         │  (sticky sidebar) │
+│                             │                   │
+└─────────────────────────────┴──────────────────┘
+```
+
+- Walks up `lo.parentLo` chain to find the enclosing topic or course
+- Renders `SecondaryNavigator` with that parent's context
+- Renders the `children` snippet (the actual content component)
+- Shows `LoContextPanel` sticky sidebar (hidden on smaller screens) listing sibling Los for navigation
+
+## CourseContext
+
+`CourseContext.svelte` — context wrapper specifically for course-level pages.
+
+**Props:** `{ children: Snippet, course: Course }`
+
+## LoContext
+
+`LoContext.svelte` — context wrapper for individual Lo pages.
+
+**Props:** `{ children: Snippet, lo: Lo }`
+
+## LoContextTree
+
+`LoContextTree.svelte` — renders a tree of sibling Los for sidebar navigation.
+
+**Props:** `{ los: Lo[], parentLo?: Lo }`
+
+Displays each sibling Lo as a clickable item, highlighting the current Lo.
+
+## LoReference
+
+`LoReference.svelte` — displays a reference/link to a Lo with its icon and title.
+
+**Props:** `{ lo: Lo }`

--- a/.tessl/tiles/tessl/tutors-ui/docs/utility-components.md
+++ b/.tessl/tiles/tessl/tutors-ui/docs/utility-components.md
@@ -1,0 +1,56 @@
+# Utility Components
+
+Shared utility components used across the application. Located in `src/lib/ui/components/`.
+
+## Icon
+
+`Icon.svelte` — renders Iconify icons.
+
+Displays an icon from the Iconify icon set. Used throughout the application for Lo type icons, navigation icons, and UI indicators.
+
+## IconBar
+
+`IconBar.svelte` — horizontal bar of navigation icons.
+
+**Props:** `{ iconNavBar: IconNavBar }`
+
+Renders a row of clickable `IconNav` items, each with a link, icon type, tooltip, and target. Used for companion links and wall navigation in `SecondaryNavigator`.
+
+## Image
+
+`Image.svelte` — learning object image display.
+
+Handles image loading, fallbacks, and responsive sizing for Lo thumbnails in cards and headers.
+
+## Menu / MenuItem
+
+`Menu.svelte` + `MenuItem.svelte` — dropdown menu components.
+
+Used for theme selection, layout switching, and other multi-option controls in the navigator.
+
+## Sidebar
+
+`Sidebar.svelte` — collapsible sidebar navigation.
+
+Used for table-of-contents navigation and lab step lists.
+
+## LanguageSwitcher
+
+`LanguageSwitcher.svelte` — locale selector dropdown.
+
+Displays the 5 supported locales (en, fr, de, it, es) and calls `setLocale()` on selection. Shows the current locale flag/label.
+
+## KeyboardShortcutsOverlay
+
+`KeyboardShortcutsOverlay.svelte` — modal overlay showing available keyboard shortcuts.
+
+- Toggled by pressing `?` (sets `shortcutsOverlayOpen` rune)
+- Closed by pressing `Esc`
+- Displays shortcuts from `getActiveCategories(currentLo.value?.type)` — shows general shortcuts plus context-specific shortcuts for the current Lo type (lab, talk, or notebook)
+
+## Brand Icons
+
+| Component | Purpose |
+|---|---|
+| `SetuIcon.svelte` | SETU (South East Technological University) logo |
+| `TutorsIcon.svelte` | Tutors platform logo/icon |

--- a/.tessl/tiles/tessl/tutors-ui/tile.json
+++ b/.tessl/tiles/tessl/tutors-ui/tile.json
@@ -1,0 +1,6 @@
+{
+  "name": "tessl/tutors-ui",
+  "version": "15.2.0",
+  "docs": "docs/index.md",
+  "summary": "Tutors UI component library: TutorsShell layout, Composite/Card/Cards/Panels/Units structure components, content renderers (Lab, Talk variants, Note, Video, Notebook), navigation (MainNavigator, SecondaryNavigator, Breadcrumbs), and utility components."
+}

--- a/tessl.json
+++ b/tessl.json
@@ -60,6 +60,21 @@
     },
     "tessl/npm-vite": {
       "version": "7.1.0"
+    },
+    "tessl/tutors-architecture": {
+      "version": "15.2.0"
+    },
+    "tessl/tutors-content-types": {
+      "version": "15.2.0"
+    },
+    "tessl/tutors-services": {
+      "version": "15.2.0"
+    },
+    "tessl/tutors-routing": {
+      "version": "15.2.0"
+    },
+    "tessl/tutors-ui": {
+      "version": "15.2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds 5 custom Tessl documentation tiles that describe the Tutors platform's own architecture, making this knowledge available to AI coding agents via the Tessl MCP server's `query_library_docs` tool
- Registers all 5 tiles in `tessl.json` alongside the existing npm dependency tiles
- The Tessl MCP server was previously only serving third-party library docs (Svelte, SvelteKit, Tailwind, etc.) — these tiles extend it with project-specific context

## Rationale

AI agents working on Tutors produce better code when they understand the platform's domain-specific patterns — the Lo type system, service-layer singletons, CDN course loading, rune-based state management, and component hierarchy. Without this context, agents guess at interfaces, miss caching patterns, and produce code that doesn't match existing conventions.

Tessl tiles solve this by providing structured, queryable documentation that the MCP server can serve on demand. Rather than relying on agents to grep through source files, the `query_library_docs` tool returns focused documentation with exact TypeScript signatures, data flow descriptions, and architectural context.

This is a stepping stone toward a dedicated Tutors MCP server (#1104) that would offer dynamic, runtime-queryable access to live course data and project structure.

## Tiles Added

| Tile | Files | Coverage |
|---|---|---|
| `tutors-architecture` | 6 | Project structure, data flow, state management, external integrations, authentication |
| `tutors-content-types` | 6 | Lo type hierarchy, all 17 types with exact TypeScript definitions, type utilities |
| `tutors-services` | 8 | All 7 service areas (course, community, connect, markdown, themes, i18n, a11y) with full interface signatures |
| `tutors-routing` | 5 | 4 route groups, complete course-reader route table, data loading patterns |
| `tutors-ui` | 7 | Component directory structure, shell/navigation, layout components, content renderers, utilities |

**Total: 32 new files, 2,482 lines of documentation**

## Related

- Closes groundwork for #1104 (dedicated Tutors MCP server)

## Test plan

- [ ] Verify all 5 tile directories exist under `.tessl/tiles/tessl/tutors-*/`
- [ ] Verify each tile has a valid `tile.json` with `name`, `version`, `docs`, `summary`
- [ ] Verify `tessl.json` has 5 new entries under `dependencies`
- [ ] Enable the Tessl MCP server locally (`disabledMcpjsonServers: []` in `.claude/settings.local.json`) and confirm `query_library_docs` can serve the new tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)