### PR TITLE
Add programme view for grouping courses into degree streams

### DIFF
--- a/docs/programme-guide.md
+++ b/docs/programme-guide.md
@@ -1,0 +1,183 @@
+# Tutors Programme Guide
+
+A programme groups multiple Tutors courses (modules) into a single degree stream, allowing learners to view all related courses through one unified page.
+
+## Overview
+
+In Tutors, a **course** is the fundamental unit of content. A **programme** sits above courses, providing a container that links related courses together — for example, all modules in a "Higher Diploma in Computer Science" degree.
+
+The programme feature introduces:
+
+- A `programme.json` manifest that defines the programme and lists its courses
+- A `/programme/[programmeid]` route in the Tutors reader that renders the programme view
+- A breadcrumb back-link from child courses to their parent programme
+
+## Creating a Programme
+
+### 1. Write `programme.json`
+
+Create a `programme.json` file with the following structure:
+
+```json
+{
+  "title": "HDip in Computer Science",
+  "summary": "A conversion programme covering core CS fundamentals",
+  "img": "banner.png",
+  "icon": { "type": "fluent:hat-graduation-24-filled", "color": "success" },
+  "courses": [
+    "module-web-dev",
+    "module-databases",
+    "module-algorithms"
+  ],
+  "properties": {
+    "credits": "120 ECTS"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Programme display name |
+| `summary` | Yes | Short description shown below the title |
+| `img` | No | Path to a banner image (relative to the programme root) |
+| `icon` | No | Iconify icon object with `type` and `color` fields. Displayed when no image is set. Browse icons at [Iconify](https://icon-sets.iconify.design/) |
+| `courses` | Yes | Array of course IDs. Each ID corresponds to a deployed Tutors course (e.g., the Netlify subdomain) |
+| `properties` | No | Key-value metadata. `credits` is displayed in the programme header if present |
+
+### 2. Deploy the Programme
+
+Deploy the `programme.json` to a static hosting provider. The recommended approach mirrors how courses are deployed:
+
+- **Netlify**: Deploy a repository containing `programme.json` to Netlify. The programme ID becomes the Netlify subdomain (e.g., `my-programme.netlify.app/programme.json`)
+- **Any static host**: The reader accepts full URLs as well as Netlify subdomain IDs
+
+### 3. Access the Programme
+
+Navigate to the programme in the Tutors reader:
+
+```
+https://tutors.dev/programme/{programme-id}
+```
+
+For example, if your programme is deployed at `hdip-comp-sci.netlify.app`:
+
+```
+https://tutors.dev/programme/hdip-comp-sci
+```
+
+The reader fetches `programme.json`, loads metadata for each listed course in parallel, and renders them as clickable course cards.
+
+## Linking Child Courses Back to the Programme
+
+To add a breadcrumb back-link from a course to its parent programme, add the `parent` property to the course's `properties.yaml`:
+
+```yaml
+parent: programme/hdip-comp-sci
+```
+
+This renders a home icon in the course's breadcrumb bar that navigates back to the programme page. The value must match the route path: `programme/{programme-id}`.
+
+## Local Development
+
+To test a programme locally before deploying:
+
+### Serve `programme.json` with CORS
+
+The programme JSON needs to be served on a local port with CORS headers enabled. Create a `serve.py` in your programme directory:
+
+```python
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import os
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+class CORSHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.end_headers()
+
+print("Serving programme.json on http://localhost:3201")
+HTTPServer(("", 3201), CORSHandler).serve_forever()
+```
+
+Run it:
+
+```bash
+python serve.py
+```
+
+### Start the Tutors reader
+
+In a separate terminal:
+
+```bash
+cd tutors
+npm run dev
+```
+
+### View the programme
+
+Open in your browser:
+
+```
+http://localhost:5173/programme/localhost:3201
+```
+
+The reader resolves `localhost:3201` as a local URL, fetches `http://localhost:3201/programme.json`, and loads the child course metadata from their live Netlify deployments.
+
+## Architecture
+
+### How It Works
+
+```
+programme.json (hosted on Netlify or local)
+  |
+  v
+programmeService.readProgramme()
+  |
+  +-- Fetches programme.json from {programmeId}.netlify.app
+  +-- For each course ID in the courses array:
+  |     +-- Fetches {courseId}.netlify.app/tutors.json
+  |     +-- Extracts: title, summary, img, icon, credits
+  |
+  v
+ProgrammeView.svelte
+  |
+  +-- Renders programme header (title, summary, icon, credits)
+  +-- Renders course cards using the existing Card component
+```
+
+### Key Files (in the `tutors` reader)
+
+| File | Purpose |
+|------|---------|
+| `src/lib/services/programme/types.ts` | Type definitions: `ProgrammeJson`, `ProgrammeCourseSummary`, `Programme` |
+| `src/lib/services/programme/services/programme.svelte.ts` | Service that fetches and caches programme data |
+| `src/lib/services/programme/index.ts` | Barrel export |
+| `src/routes/(programme)/+layout.svelte` | Route group layout |
+| `src/routes/(programme)/programme/[programmeid]/+page.ts` | Data loader |
+| `src/routes/(programme)/programme/[programmeid]/+page.svelte` | Page component |
+| `src/lib/ui/programme/ProgrammeView.svelte` | View component with header and course grid |
+
+### Existing Mechanisms Used
+
+- **`determineCourseUrl()`** — resolves programme and course IDs to URLs (Netlify subdomains, full URLs, or localhost)
+- **`Card` component** — reused for rendering course cards in the programme view
+- **`properties.parent` + `programHome` icon** — existing breadcrumb mechanism for child-to-parent navigation
+
+## Example Repository
+
+See [lgriffin/tutors-programme](https://github.com/lgriffin/tutors-programme) for a working example that links three courses into a single programme.
+
+## Limitations
+
+- **No combined analytics or progress tracking** — the programme view is read-only; analytics remain per-course
+- **No cross-course search** — search operates within individual courses
+- **One-way relationship** — the programme knows its courses, but courses only link back via the optional `parent` property
+- **Manual authoring** — `programme.json` is hand-written; there is no generator in tutors-apps yet

--- a/src/lib/services/programme/index.ts
+++ b/src/lib/services/programme/index.ts
@@ -1,0 +1,2 @@
+export { programmeService } from "./services/programme.svelte";
+export type { Programme, ProgrammeCourseSummary, ProgrammeJson } from "./types";

--- a/src/lib/services/programme/services/programme.svelte.ts
+++ b/src/lib/services/programme/services/programme.svelte.ts
@@ -1,0 +1,65 @@
+import { determineCourseUrl } from "$lib/services/course/services/lo-tree";
+import type { Programme, ProgrammeCourseSummary, ProgrammeJson } from "../types";
+
+const programmes = new Map<string, Programme>();
+
+function protocolFor(url: string): string {
+  const isLocal = url.startsWith("localhost") || url.startsWith("192");
+  return isLocal ? "http://" : "https://";
+}
+
+async function fetchCourseSummary(courseId: string, fetchFunction: typeof fetch): Promise<ProgrammeCourseSummary> {
+  const { courseId: normalizedCourseId, courseUrl } = determineCourseUrl(courseId);
+  const protocol = protocolFor(courseUrl);
+  const response = await fetchFunction(`${protocol}${courseUrl}/tutors.json`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch course ${courseId}: ${response.status}`);
+  }
+  const data = await response.json();
+  return {
+    courseId: normalizedCourseId,
+    title: data.title,
+    summary: data.summary,
+    img: data.img ? `${protocol}${courseUrl}/${data.img}` : undefined,
+    icon: data.icon ?? data.properties?.icon,
+    credits: data.properties?.credits,
+    route: `/course/${normalizedCourseId}`
+  };
+}
+
+export const programmeService = {
+  async readProgramme(programmeId: string, fetchFunction: typeof fetch): Promise<Programme> {
+    let programme = programmes.get(programmeId);
+    if (programme) return programme;
+
+    const { courseId: normalizedId, courseUrl } = determineCourseUrl(programmeId);
+    const protocol = protocolFor(courseUrl);
+
+    const response = await fetchFunction(`${protocol}${courseUrl}/programme.json`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch programme: ${response.status}`);
+    }
+    const programmeJson: ProgrammeJson = await response.json();
+
+    const courseResults = await Promise.allSettled(
+      programmeJson.courses.map((courseId) => fetchCourseSummary(courseId, fetchFunction))
+    );
+
+    const courses: ProgrammeCourseSummary[] = courseResults
+      .filter((r): r is PromiseFulfilledResult<ProgrammeCourseSummary> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    programme = {
+      programmeId: normalizedId,
+      title: programmeJson.title,
+      summary: programmeJson.summary,
+      img: programmeJson.img ? `${protocol}${courseUrl}/${programmeJson.img}` : undefined,
+      icon: programmeJson.icon,
+      properties: programmeJson.properties,
+      courses
+    };
+
+    programmes.set(normalizedId, programme);
+    return programme;
+  }
+};

--- a/src/lib/services/programme/types.ts
+++ b/src/lib/services/programme/types.ts
@@ -1,0 +1,30 @@
+import type { IconType } from "@tutors/tutors-model-lib";
+
+export interface ProgrammeJson {
+  title: string;
+  summary: string;
+  img?: string;
+  icon?: IconType;
+  courses: string[];
+  properties?: Record<string, string>;
+}
+
+export interface ProgrammeCourseSummary {
+  courseId: string;
+  title: string;
+  summary: string;
+  img?: string;
+  icon?: IconType;
+  credits?: string;
+  route: string;
+}
+
+export interface Programme {
+  programmeId: string;
+  title: string;
+  summary: string;
+  img?: string;
+  icon?: IconType;
+  properties?: Record<string, string>;
+  courses: ProgrammeCourseSummary[];
+}

--- a/src/lib/services/themes/icons/easter-icons.ts
+++ b/src/lib/services/themes/icons/easter-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const EasterIcons: IconLib = {
   // Home Icon
   programHome: { type: "bxs:home-circle", color: "success" },
+  programme: { type: "bxs:graduation", color: "success" },
 
   // companion Icons
   slack: { type: "logos:slack-icon", color: "error" },

--- a/src/lib/services/themes/icons/festive-icons.ts
+++ b/src/lib/services/themes/icons/festive-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const FestiveIcons: IconLib = {
   // Home Icon
   programHome: { type: "tabler:christmas-ball", color: "success" },
+  programme: { type: "tabler:school", color: "success" },
 
   // companion Icons
   slack: { type: "logos:slack-icon", color: "error" },

--- a/src/lib/services/themes/icons/fluent-icons.ts
+++ b/src/lib/services/themes/icons/fluent-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const FluentIconLib: IconLib = {
   // Home Icon
   programHome: { type: "fluent:home-24-filled", color: "success" },
+  programme: { type: "fluent:hat-graduation-24-filled", color: "success" },
 
   // companion Icons
   slack: { type: "logos:slack-icon", color: "error" },

--- a/src/lib/services/themes/icons/halloween-icons.ts
+++ b/src/lib/services/themes/icons/halloween-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const HalloweenIconLib: IconLib = {
   // Home type
   programHome: { type: "cib:nodemon", color: "warning" },
+  programme: { type: "mdi:school-outline", color: "warning" },
 
   // companion types
   slack: { type: "fluent:chat-24-filled", color: "warning" },

--- a/src/lib/services/themes/icons/hero-icons.ts
+++ b/src/lib/services/themes/icons/hero-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const HeroIconLib: IconLib = {
   // Home Icon
   programHome: { type: "heroicons-outline:home", color: "success" },
+  programme: { type: "heroicons-outline:academic-cap", color: "success" },
 
   // companion Icons
   slack: { type: "grommet-icons:slack", color: "error" },

--- a/src/lib/services/themes/icons/valentine-icons.ts
+++ b/src/lib/services/themes/icons/valentine-icons.ts
@@ -3,6 +3,7 @@ import type { IconLib } from "../types";
 export const ValentineIcons: IconLib = {
   // Home Icon
   programHome: { type: "fluent:home-heart-32-filled", color: "success" },
+  programme: { type: "fluent:hat-graduation-24-filled", color: "success" },
 
   // companion Icons
   slack: { type: "logos:slack-icon", color: "error" },

--- a/src/lib/ui/programme/ProgrammeView.svelte
+++ b/src/lib/ui/programme/ProgrammeView.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { Programme } from "$lib/services/programme";
+  import Card from "$lib/ui/learning-objects/layout/Card.svelte";
+  import Icon from "$lib/ui/components/Icon.svelte";
+
+  interface Props {
+    programme: Programme;
+  }
+  let { programme }: Props = $props();
+</script>
+
+<div class="mx-auto max-w-7xl p-4">
+  <div class="card preset-filled-surface-100-900 m-4 border border-surface-200 p-6 dark:border-surface-700">
+    <div class="flex items-center gap-6">
+      {#if programme.icon}
+        <Icon type="programme" height="60" />
+      {:else if programme.img}
+        <img src={programme.img} alt={programme.title} class="h-20 rounded-xl" />
+      {/if}
+      <div>
+        <h1 class="text-3xl font-bold">{programme.title}</h1>
+        <p class="mt-2 text-lg opacity-80">{programme.summary}</p>
+        {#if programme.properties?.credits}
+          <p class="mt-1 text-sm opacity-60">{programme.properties.credits}</p>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-wrap justify-center">
+    {#each programme.courses as course}
+      <Card
+        cardDetails={{
+          route: course.route,
+          title: course.title,
+          type: "course",
+          summary: course.credits ?? course.summary,
+          img: course.img,
+          icon: course.icon
+        }}
+        cardLayout={{
+          layout: "compacted",
+          style: "landscape"
+        }}
+      />
+    {/each}
+  </div>
+</div>

--- a/src/routes/(programme)/+layout.svelte
+++ b/src/routes/(programme)/+layout.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { currentCourse } from "$lib/runes.svelte";
+  import CourseShell from "$lib/ui/TutorsShell.svelte";
+  import type { Snippet } from "svelte";
+  type Props = { children: Snippet };
+  let { children }: Props = $props();
+
+  currentCourse.value = null;
+</script>
+
+<svelte:head>
+  <title>Tutors</title>
+</svelte:head>
+
+<CourseShell>
+  {@render children()}
+</CourseShell>

--- a/src/routes/(programme)/programme/[programmeid]/+page.svelte
+++ b/src/routes/(programme)/programme/[programmeid]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import ProgrammeView from "$lib/ui/programme/ProgrammeView.svelte";
+  import type { Programme } from "$lib/services/programme";
+
+  interface Props {
+    data: { programme: Programme };
+  }
+  let { data }: Props = $props();
+</script>
+
+<svelte:head>
+  <title>{data.programme.title}</title>
+</svelte:head>
+
+<ProgrammeView programme={data.programme} />

--- a/src/routes/(programme)/programme/[programmeid]/+page.ts
+++ b/src/routes/(programme)/programme/[programmeid]/+page.ts
@@ -1,0 +1,8 @@
+import { programmeService } from "$lib/services/programme";
+
+export const ssr = false;
+
+export const load = async ({ params, fetch }) => {
+  const programme = await programmeService.readProgramme(params.programmeid, fetch);
+  return { programme };
+};


### PR DESCRIPTION
## Summary

- Adds a `/programme/[programmeid]` route that renders multiple courses as a unified programme page
- A programme is defined by a lightweight `programme.json` manifest hosted on Netlify (same as courses host `tutors.json`)
- Fetches child course metadata in parallel and renders them as clickable course cards using the existing `Card` component
- Adds `programme` icon to all 6 icon theme libraries
- Includes full documentation in `docs/programme-guide.md`

## How it works

1. Author a `programme.json` listing course IDs and deploy it to Netlify
2. Navigate to `tutors.dev/programme/{programme-id}`
3. The reader fetches the manifest, loads each course's `tutors.json` for metadata, and renders a programme header + course card grid
4. Child courses can optionally set `parent: "programme/{id}"` in their `properties.yaml` for a breadcrumb back-link (uses the existing `programHome` mechanism)

## Example

See [lgriffin/tutors-programme](https://github.com/lgriffin/tutors-programme) for a working sample that groups three courses into an "HDip in Computer Science" programme.

## Test plan

- [ ] Run `npm run dev` and navigate to `/programme/localhost:3201` with the sample programme served locally
- [ ] Verify programme header renders with title, summary, icon, and credits
- [ ] Verify course cards render and link to `/course/{courseId}`
- [ ] Verify graceful degradation when a listed course ID doesn't exist (card omitted, no crash)
- [ ] Verify `vite build` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)